### PR TITLE
Remove unnecessary parameters

### DIFF
--- a/.idea/runConfigurations/kotlin_components__logging_publishToMavenLocal_.xml
+++ b/.idea/runConfigurations/kotlin_components__logging_publishToMavenLocal_.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="kotlin-components [logging:publishToMavenLocal]" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
@@ -10,7 +9,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-x kotlinNpmInstall" />
+      <option name="scriptParameters" value="" />
       <option name="taskDescriptions">
         <list />
       </option>
@@ -25,4 +24,3 @@
     <method v="2" />
   </configuration>
 </component>
-

--- a/.idea/runConfigurations/publishToMavenLocal.xml
+++ b/.idea/runConfigurations/publishToMavenLocal.xml
@@ -4,7 +4,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-x kotlinNpmInstall" />
+      <option name="scriptParameters" value="" />
       <option name="taskDescriptions">
         <list />
       </option>


### PR DESCRIPTION
Fix run tasks from IDE:

```
Task 'kotlinNpmInstall' not found in root project 'Kaluga'.
```

Removed `-x kotlinNpmInstall` from parameters 