### PR TITLE
Hud enhancement test coverage

### DIFF
--- a/hud/src/androidLibAndroidTest/kotlin/AndroidHUDTests.kt
+++ b/hud/src/androidLibAndroidTest/kotlin/AndroidHUDTests.kt
@@ -1,8 +1,5 @@
 package com.splendo.kaluga.hud
 
-import android.content.Context
-import androidx.test.InstrumentationRegistry.getTargetContext
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.By
@@ -171,7 +168,6 @@ class AndroidHUDTests {
         // HUD should be on screen
         device.assertTextAppears(LOADING)
         assertTrue(indicator.isVisible)
-
 
         indicator.dismiss()
         // Finally should be gone

--- a/hud/src/androidLibAndroidTest/kotlin/AndroidHUDTests.kt
+++ b/hud/src/androidLibAndroidTest/kotlin/AndroidHUDTests.kt
@@ -56,12 +56,12 @@ class AndroidHUDTests {
     }
 
     @Test
-    fun builderInitializer() {
+    fun `builder_should_build_HUD`() {
         assertNotNull(builder.build())
     }
 
     @Test
-    fun indicatorShow() {
+    fun `present_should_show_indicator_with_appropriate_text`() {
         val indicator = builder.build {
             setTitle(LOADING)
         }.present()
@@ -70,7 +70,7 @@ class AndroidHUDTests {
     }
 
     @Test
-    fun indicatorDismiss() {
+    fun `dismiss_dismisses_indicator`() {
         val indicator = builder.build {
             setTitle(LOADING)
         }.present()
@@ -82,7 +82,7 @@ class AndroidHUDTests {
     }
 
     @Test
-    fun indicatorDismissAfter() {
+    fun `dismissAfter_dismisses_indicator`() {
         val indicator = builder.build {
             setTitle(LOADING)
         }.present()
@@ -94,7 +94,7 @@ class AndroidHUDTests {
     }
 
     @Test
-    fun testPresentDuring() = runBlockingTest {
+    fun `presentDuring_shows_indicator_while_closure_is_executing`() = runBlockingTest {
         lateinit var indicatorProcessing: HUD
 
         val loading1 = EmptyCompletableDeferred()
@@ -134,7 +134,7 @@ class AndroidHUDTests {
     }
 
     @Test
-    fun rotateActivity() {
+    fun `hud_should_stay_on_screen_if_it_rotates`() {
         val indicator = builder.build {
             setTitle(LOADING)
         }.present()

--- a/hud/src/androidLibAndroidTest/kotlin/AndroidHUDTests.kt
+++ b/hud/src/androidLibAndroidTest/kotlin/AndroidHUDTests.kt
@@ -163,15 +163,7 @@ class AndroidHUDTests {
     fun `hud_should_keep_showing_if_app_gos_to_background_and_returns_back`() {
         val indicator = buildAndPresentLoadingHUD()
 
-        // val appLabel = getApplicationInfo().loadLabel(getPackageManager()).toString();
-        // .applicationInfo.labelRes
-        //getTargetContext().getString(getTargetContext().getApplicationInfo().labelRes))
-
-        val activity = activityRule.activity
-        // println("activity.applicationInfo.labelRes : ${ activity.applicationInfo.labelRes }")
-        // val appLabel = activity.getString(activity.applicationInfo.labelRes)
-        val appLabel = "com.splendo.kaluga.hud.TestActivity"
-
+        val appLabel = activityRule.activity.localClassName
         device.pressHome()
         device.pressRecentApps()
         device.findObject(UiSelector().text(appLabel)).click()

--- a/hud/src/androidLibAndroidTest/kotlin/AndroidHUDTests.kt
+++ b/hud/src/androidLibAndroidTest/kotlin/AndroidHUDTests.kt
@@ -55,6 +55,19 @@ class AndroidHUDTests {
         const val PROCESSING = "Processing..."
     }
 
+    private fun buildAndPresentLoadingHUD(): HUD {
+        val indicator = builder.build {
+            setTitle(LOADING)
+        }.present()
+        device.assertTextAppears(LOADING)
+        assertTrue(indicator.isVisible)
+        return indicator
+    }
+
+    private fun rotateScreen() {
+        device.setOrientationLeft()
+    }
+
     @Test
     fun `builder_should_build_HUD`() {
         assertNotNull(builder.build())
@@ -71,11 +84,7 @@ class AndroidHUDTests {
 
     @Test
     fun `dismiss_dismisses_indicator`() {
-        val indicator = builder.build {
-            setTitle(LOADING)
-        }.present()
-        device.assertTextAppears(LOADING)
-        assertTrue(indicator.isVisible)
+        val indicator = buildAndPresentLoadingHUD()
         indicator.dismiss()
         device.assertTextDisappears(LOADING)
         assertFalse(indicator.isVisible)
@@ -83,11 +92,7 @@ class AndroidHUDTests {
 
     @Test
     fun `dismissAfter_dismisses_indicator`() {
-        val indicator = builder.build {
-            setTitle(LOADING)
-        }.present()
-        device.assertTextAppears(LOADING)
-        assertTrue(indicator.isVisible)
+        val indicator = buildAndPresentLoadingHUD()
         indicator.dismissAfter(500)
         device.assertTextDisappears(LOADING)
         assertFalse(indicator.isVisible)
@@ -135,14 +140,10 @@ class AndroidHUDTests {
 
     @Test
     fun `hud_should_stay_on_screen_if_it_rotates`() {
-        val indicator = builder.build {
-            setTitle(LOADING)
-        }.present()
-        device.assertTextAppears(LOADING)
-        assertTrue(indicator.isVisible)
+        val indicator = buildAndPresentLoadingHUD()
 
-        // Rotate screen
-        device.setOrientationLeft()
+        rotateScreen()
+
         // HUD should be on screen
         device.assertTextAppears(LOADING)
         assertTrue(indicator.isVisible)

--- a/hud/src/androidLibAndroidTest/kotlin/AndroidHUDTests.kt
+++ b/hud/src/androidLibAndroidTest/kotlin/AndroidHUDTests.kt
@@ -1,9 +1,13 @@
 package com.splendo.kaluga.hud
 
+import android.content.Context
+import androidx.test.InstrumentationRegistry.getTargetContext
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import com.splendo.kaluga.utils.EmptyCompletableDeferred
 import com.splendo.kaluga.utils.complete
@@ -149,6 +153,34 @@ class AndroidHUDTests {
         assertTrue(indicator.isVisible)
 
         device.setOrientationNatural()
+        indicator.dismiss()
+        // Finally should be gone
+        device.assertTextDisappears(LOADING)
+        assertFalse(indicator.isVisible)
+    }
+
+    @Test
+    fun `hud_should_keep_showing_if_app_gos_to_background_and_returns_back`() {
+        val indicator = buildAndPresentLoadingHUD()
+
+        // val appLabel = getApplicationInfo().loadLabel(getPackageManager()).toString();
+        // .applicationInfo.labelRes
+        //getTargetContext().getString(getTargetContext().getApplicationInfo().labelRes))
+
+        val activity = activityRule.activity
+        // println("activity.applicationInfo.labelRes : ${ activity.applicationInfo.labelRes }")
+        // val appLabel = activity.getString(activity.applicationInfo.labelRes)
+        val appLabel = "com.splendo.kaluga.hud.TestActivity"
+
+        device.pressHome()
+        device.pressRecentApps()
+        device.findObject(UiSelector().text(appLabel)).click()
+
+        // HUD should be on screen
+        device.assertTextAppears(LOADING)
+        assertTrue(indicator.isVisible)
+
+
         indicator.dismiss()
         // Finally should be gone
         device.assertTextDisappears(LOADING)


### PR DESCRIPTION
* Renamed HUD tests in a more informative way. Unfortunately, I was not able to use backtick-quoted names and this issue should be figured out. As an alternative, I've used underscore naming.
* Added test cases which caused issues in WTS,  they are not failing though. We should figure out how to simulate WTS issues properly. Some of these tests can be deleted after implementing present/dismiss as suspended functions.