### PR TITLE
Fix publish *.module

### DIFF
--- a/gradle/ext.gradle
+++ b/gradle/ext.gradle
@@ -10,7 +10,7 @@ gradle.ext {
     koin_version = '3.0.0-alpha-4'
     serialization_version = '1.0.1'
     bintray_plugin_version = '1.8.5'
-    library_version = '0.1.1'
+    library_version = '0.1.2'
     android_min_sdk_version = 21
     android_target_sdk_version = 29
     android_build_tools_version = "29.0.3"

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -76,18 +76,14 @@ afterEvaluate {
             root.appendNode('url', 'https://github.com/splendo/kaluga')
             root.children().last() + pomConfig
         }
-        boolean isPublishTask = gradle.startParameter.taskNames
-                .any  {it.startsWith("publish") || it.startsWith("bintray") }
+        boolean isPublishToMavenLocalTask = gradle.startParameter.taskNames.any { it == "publishToMavenLocal" }
         File moduleFile = new File(project.buildDir, "publications/${publication.name}/module.json")
-        if (!isPublishTask && moduleFile.exists()) {
+        if (!isPublishToMavenLocalTask && moduleFile.exists()) {
             publication.artifact(new FileBasedMavenArtifact(moduleFile) {
                 protected String getDefaultExtension() {
                     return 'module'
                 }
             })
         }
-    }
-    tasks.named("bintrayUpload").configure { task ->
-        dependsOn publishToMavenLocal
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fix for #162 

Unfortunately bintrayUpload task conflicts with publishToMavenLocal when uses dependsOn because of duplicate:

```
> Task :alerts:publishAndroidLibDebugPublicationToMavenLocal FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':alerts:publishAndroidLibDebugPublicationToMavenLocal'.
> Failed to publish publication 'androidLibDebug' to repository 'mavenLocal'
   > Invalid publication 'androidLibDebug': multiple artifacts with the identical extension and classifier ('module', 'null').
```

And my workaround was not working as expected, since we are going to use CI to publish, I think its okay if we can run publishToMavenLocal before bintrayUpload just in shell script.

