### PR TITLE
Bump version 0.1.3 and readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,21 @@ Most of the components within this project use Kotlin coroutines and `Flow` to d
  
 ## Publishing
 
-Kaluga is published on Bintray and available in JCenter. Also it can be published to your local maven repo.
+The libraries are not published on any hosted repository yet, but can be published to your local maven repo.
+
+In same time it is available via Bintray. Here is example how to include alerts module your into project:
+
+```kotlin
+repositories {
+    // ...
+    maven("https://dl.bintray.com/splendo/kaluga")
+}
+// ...
+dependencies {
+    // ...
+    api("com.splendo.kaluga:alerts:0.1.3")
+}
+```
 
 ### Publishing process
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,32 @@ Most of the components within this project use Kotlin coroutines and `Flow` to d
  
 ## Publishing
 
-The libraries are not published on any hosted repository yet, but can be published to your local maven repo  
- 
+Kaluga is published on Bintray and available in JCenter. Also it can be published to your local maven repo.
+
+### Publishing process
+
+1. Bump version at `gradle/ext.gradle`:
+
+```sh
+library_version = 'X.X.X'
+```
+
+2. Publish to local maven:
+
+```sh
+./gradlew publishToMavenLocal
+```
+
+3. Upload and publish on Bintray:
+
+```sh
+./gradlew -Pbintray_user=splendo -Pbintray_key=API_KEY -Pbintray_dry_run=false -Pbintray_publish=true bintrayUpload
+```
+
+Where `API_KEY` is Bintray's API key.
+`bintray_dry_run` flag set to `false` used to perform upload.
+And `bintray_publish` flag set to `true` used to perform publish.
+
 ## Code conventions
 
 The project uses regular Kotlin code conventions. This includes not creating `com/splendo/kaluga` directories, since they are common to all other folders.

--- a/gradle/ext.gradle
+++ b/gradle/ext.gradle
@@ -10,7 +10,7 @@ gradle.ext {
     koin_version = '3.0.0-alpha-4'
     serialization_version = '1.0.1'
     bintray_plugin_version = '1.8.5'
-    library_version = '0.1.2'
+    library_version = '0.1.3'
     android_min_sdk_version = 21
     android_target_sdk_version = 29
     android_build_tools_version = "29.0.3"


### PR DESCRIPTION
0.1.2 had broken alerts artefacts:

```
org.gradle.internal.resolve.ArtifactNotFoundException: Could not find alerts-debug.aar (com.splendo.kaluga:alerts-androidlib-debug:0.1.2).
Searched in the following locations:
    https://jcenter.bintray.com/com/splendo/kaluga/alerts-androidlib-debug/0.1.2/alerts-androidlib-debug-0.1.1.aar
```
