### PR TITLE
GCScheduler no longer blocks main thread when disposing

### DIFF
--- a/architecture/src/iosMain/kotlin/navigation/Navigator.kt
+++ b/architecture/src/iosMain/kotlin/navigation/Navigator.kt
@@ -69,7 +69,10 @@ actual interface Navigator<A : NavigationAction<*>> {
  * @param parent The [UIViewController] managing the navigation
  * @param navigationMapper A function mapping the [NavigationAction] to [NavigationSpec]
  */
-class ViewControllerNavigator<A : NavigationAction<*>>(parentVC: UIViewController, private val navigationMapper: (A) -> NavigationSpec) : Navigator<A> {
+class ViewControllerNavigator<A : NavigationAction<*>>(
+    parentVC: UIViewController,
+    private val navigationMapper: (A) -> NavigationSpec
+) : Navigator<A> {
 
     private inner class StoreKitDelegate : NSObject(), SKStoreProductViewControllerDelegateProtocol {
 

--- a/base/src/iosMain/kotlin/GCScheduler.kt
+++ b/base/src/iosMain/kotlin/GCScheduler.kt
@@ -43,8 +43,8 @@ object GCScheduler {
      */
     fun collectIfNotCollecting() {
         if (isCollecting.compareAndSet(expected = false, new = true)) {
-                GC.collect()
-                isCollecting.value = false
-            }
+            GC.collect()
+            isCollecting.value = false
+        }
     }
 }

--- a/base/src/iosMain/kotlin/GCScheduler.kt
+++ b/base/src/iosMain/kotlin/GCScheduler.kt
@@ -18,21 +18,33 @@
 package com.splendo.kaluga.base
 
 import co.touchlab.stately.concurrency.AtomicBoolean
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 import kotlin.native.concurrent.ThreadLocal
 import kotlin.native.internal.GC
 
+@SharedImmutable
+private val isCollecting: AtomicBoolean = AtomicBoolean(false)
+
 @ThreadLocal
 object GCScheduler {
-    private val isCollecting: AtomicBoolean = AtomicBoolean(false)
 
     /**
      * Schedules the Garbage Collector only if no other garbage collection is active.
      * This is useful in case calling the Garbage collector could trigger another call to [GC.collect].
      */
     fun schedule() {
+        MainScope().launch { collectIfNotCollecting() }
+    }
+
+    /**
+     * Runs the Garbage Collector only if no other garbage collection is active.
+     * This is useful in case calling the Garbage collector could trigger another call to [GC.collect].
+     */
+    fun collectIfNotCollecting() {
         if (isCollecting.compareAndSet(expected = false, new = true)) {
-            GC.collect()
-        }
-        isCollecting.value = false
+                GC.collect()
+                isCollecting.value = false
+            }
     }
 }


### PR DESCRIPTION
iOS was seeing issues where the garbage collector would block the UI thread and cause unresponsive UI.

This pr aims to fix this by separating the goal of *scheduling* the garbage collector from actually running it.

This also makes GarbageScheduler thread safe