### PR TITLE
 Adds ThemedColorProvider to resources module.

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -31,6 +31,23 @@ You can treat any `String` as a key to a `Color` value.
 By default, this loads the Color in the `Color Assets` (iOS) or `color.xml` (Android) files declared in the main project scope.
 A `ColorLoader` class is provided to overwrite this behaviour.
 
+### ThemedColor
+`ThemedColorProvider` can be used to obtain a `Color` that has two different values depending on the theme the system is running.
+It is aware of Dark and Light themes, and it's bound to it automatically.
+To define such a color, the following syntax can be used:
+```
+val background by themeColor(light="#FFFFFF", dark="#000000")
+```
+Platforms will be able to use this Color in their code, knowing that it comes automatically in the correct contrast depending on the theme. 
+If it's still needed to refer to the single Light and Dark colors, it can be done in the following way:
+```
+val backgroundColorProvider = themeColor(light="#FFFFFF", dark="#000000")
+val background by backgroundColorProvider
+val darkBackground = backgroundColorProvider.darkColor
+val lightBackground = backgroundColorProvider.lightColor
+
+```
+
 ### Image
 The `Image` class is associated with `UIImage` (iOS) and `Drawable` (Android).
 You can treat any `String` as a key to a `Image` value.

--- a/resources/src/androidLibMain/kotlin/ThemedColorProvider.kt
+++ b/resources/src/androidLibMain/kotlin/ThemedColorProvider.kt
@@ -1,0 +1,32 @@
+/*
+ Copyright 2021 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.resources
+
+class AndroidThemedColorProvider(light: String, dark: String): ThemedColorProvider() {
+
+    /** The dark theme version of this color, already loaded */
+    override val darkColor = colorFrom(dark)!!
+
+    /** The light theme version of this color, already loaded */
+    override val lightColor = colorFrom(light)!!
+
+    override val color get() = if (isInDarkMode) darkColor else lightColor
+}
+
+actual fun themeColor(light: String, dark: String): ThemedColorProvider
+    = AndroidThemedColorProvider(light, dark)

--- a/resources/src/commonMain/kotlin/ThemedColorProvider.kt
+++ b/resources/src/commonMain/kotlin/ThemedColorProvider.kt
@@ -1,0 +1,44 @@
+/*
+ Copyright 2021 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+@file:JvmName("CommonThemedColorProvider")
+package com.splendo.kaluga.resources
+
+import kotlin.jvm.JvmName
+import kotlin.reflect.KProperty
+
+/** Multiplatform Color Provider that is aware of a Dark and Light mode */
+abstract class ThemedColorProvider {
+
+    /** light version of this color */
+    abstract val lightColor: Color
+
+    /** dark version of this color */
+    abstract val darkColor: Color
+
+    /** main color, automatically changing based on theme */
+    abstract val color: Color
+}
+
+/** This extension allows to get the hexValue of the provided color with the "by" syntax */
+inline operator fun ThemedColorProvider.getValue(thisRef: Any?, property: KProperty<*>): Color = color
+
+/**
+ * One single color represented in 2 themes Dark or Light.
+ * @param light color when presented in Light mode: formatted as hexadecimal string
+ * @param dark color when presented in Dark mode: formatted as hexadecimal string
+ */
+expect fun themeColor(light: String, dark: String): ThemedColorProvider

--- a/resources/src/iosMain/kotlin/ThemedColorProvider.kt
+++ b/resources/src/iosMain/kotlin/ThemedColorProvider.kt
@@ -1,0 +1,39 @@
+/*
+ Copyright 2021 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.resources
+
+
+import platform.UIKit.UIColor
+import platform.UIKit.UIUserInterfaceStyle
+import platform.UIKit.colorWithDynamicProvider
+
+class IOSThemedColorProvider(light: String, dark: String): ThemedColorProvider() {
+
+    override val lightColor = colorFrom(light)!!
+    override val darkColor = colorFrom(dark)!!
+
+    override val color = Color(UIColor.colorWithDynamicProvider {
+        when (it?.userInterfaceStyle) {
+            UIUserInterfaceStyle.UIUserInterfaceStyleDark -> darkColor
+            else -> lightColor
+        }.uiColor
+    })
+}
+
+actual fun themeColor(light: String, dark: String): ThemedColorProvider
+    = IOSThemedColorProvider(light, dark)

--- a/resources/src/jsMain/kotlin/ThemedColorProvider.kt
+++ b/resources/src/jsMain/kotlin/ThemedColorProvider.kt
@@ -1,0 +1,32 @@
+/*
+ Copyright 2021 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.resources
+
+class JsThemedColorProvider(light: String, dark: String): ThemedColorProvider() {
+
+    /** The dark theme version of this color, already loaded */
+    override val darkColor = colorFrom(dark)!!
+
+    /** The light theme version of this color, already loaded */
+    override val lightColor = colorFrom(light)!!
+
+    override val color get() = if (isInDarkMode) darkColor else lightColor
+}
+
+actual fun themeColor(light: String, dark: String): ThemedColorProvider
+    = JsThemedColorProvider(light, dark)

--- a/resources/src/jvmMain/kotlin/ThemedColorProvider.kt
+++ b/resources/src/jvmMain/kotlin/ThemedColorProvider.kt
@@ -1,0 +1,32 @@
+/*
+ Copyright 2021 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.resources
+
+class JvmThemedColorProvider(light: String, dark: String): ThemedColorProvider() {
+
+    /** The dark theme version of this color, already loaded */
+    override val darkColor = colorFrom(dark)!!
+
+    /** The light theme version of this color, already loaded */
+    override val lightColor = colorFrom(light)!!
+
+    override val color get() = if (isInDarkMode) darkColor else lightColor
+}
+
+actual fun themeColor(light: String, dark: String): ThemedColorProvider
+    = JvmThemedColorProvider(light, dark)


### PR DESCRIPTION
Draft for #336 

Introduces the concept of a color that is aware of Dark/Light mode and it gives the proper value automatically.

Advantages:
- the actual colors are not constantly re-created from the hex values, but they are chaced
- on iOS side, `colorWithDynamicProvider` is used, which brings this functionality automatically
- on Android side, the color value will not be cached but rather provided every time depending on the theme
- if, for any reason, access to each theme value is still needed it remains possible by calling Provider.darkColor or Provider.lightColor