### PR TITLE
Fixes/keyboard lifecycle bug

### DIFF
--- a/example/android/src/main/java/com/splendo/kaluga/example/di/Modules.kt
+++ b/example/android/src/main/java/com/splendo/kaluga/example/di/Modules.kt
@@ -174,8 +174,8 @@ val viewModelModule = module {
         HudViewModel(HUD.Builder())
     }
 
-    viewModel { (activity: Activity, focusHandler: FocusHandler) ->
-        KeyboardViewModel(KeyboardManager.Builder(activity), focusHandler)
+    viewModel { (keyboardBuilder: KeyboardManager.Builder, focusHandler: FocusHandler) ->
+        KeyboardViewModel(keyboardBuilder, focusHandler)
     }
 
     viewModel {

--- a/example/android/src/main/java/com/splendo/kaluga/example/keyboard/KeyboardManagerActivity.kt
+++ b/example/android/src/main/java/com/splendo/kaluga/example/keyboard/KeyboardManagerActivity.kt
@@ -24,12 +24,17 @@ import com.splendo.kaluga.architecture.viewmodel.KalugaViewModelActivity
 import com.splendo.kaluga.example.R
 import com.splendo.kaluga.example.shared.viewmodel.keyboard.KeyboardViewModel
 import com.splendo.kaluga.keyboard.AndroidFocusHandler
+import com.splendo.kaluga.keyboard.keyboardManagerBuilder
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 
 class KeyboardManagerActivity : KalugaViewModelActivity<KeyboardViewModel>(R.layout.activity_keyboard_manager) {
 
-    override val viewModel: KeyboardViewModel by viewModel { parametersOf(this, AndroidFocusHandler(this, R.id.edit_field) ) }
+    override val viewModel: KeyboardViewModel by viewModel {
+        parametersOf(
+            keyboardManagerBuilder(),
+            AndroidFocusHandler(R.id.edit_field) )
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/example/shared/src/commonMain/kotlin/viewmodel/keyboard/KeyboardViewModel.kt
+++ b/example/shared/src/commonMain/kotlin/viewmodel/keyboard/KeyboardViewModel.kt
@@ -6,7 +6,7 @@ import com.splendo.kaluga.keyboard.FocusHandler
 
 class KeyboardViewModel(keyboardManagerBuilder: BaseKeyboardManager.Builder, private val editFieldFocusHandler: FocusHandler) : BaseViewModel() {
 
-    private val keyboardManager: BaseKeyboardManager = keyboardManagerBuilder.create()
+    private val keyboardManager: BaseKeyboardManager = keyboardManagerBuilder.create(coroutineScope)
 
     fun onShowPressed() {
         keyboardManager.show(editFieldFocusHandler)

--- a/keyboard/src/androidLibAndroidTest/kotlin/TestActivity.kt
+++ b/keyboard/src/androidLibAndroidTest/kotlin/TestActivity.kt
@@ -20,6 +20,7 @@ package com.splendo.kaluga.keyboard
 import android.os.Bundle
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 
 class TestActivity : AppCompatActivity() {
 
@@ -35,6 +36,6 @@ class TestActivity : AppCompatActivity() {
     }
 
     fun showKeyboard() {
-        keyboardManagerBuilder(this).create().show(AndroidFocusHandler(this, view.id))
+        keyboardManagerBuilder().create(lifecycleScope).show(AndroidFocusHandler(view.id))
     }
 }

--- a/keyboard/src/androidLibMain/kotlin/FocusHandler.kt
+++ b/keyboard/src/androidLibMain/kotlin/FocusHandler.kt
@@ -23,11 +23,11 @@ import androidx.annotation.IdRes
 import androidx.compose.ui.focus.FocusRequester
 
 actual interface FocusHandler {
-    fun requestFocus(activity: Activity)
+    fun requestFocus(activity: Activity?)
 }
 
 class ComposeFocusHandler(private val focusRequester: FocusRequester) : FocusHandler {
-    override fun requestFocus(activity: Activity) {
+    override fun requestFocus(activity: Activity?) {
         focusRequester.requestFocus()
     }
 }
@@ -35,8 +35,8 @@ class ComposeFocusHandler(private val focusRequester: FocusRequester) : FocusHan
 class AndroidFocusHandler(
     @IdRes private val id: Int
 ) : FocusHandler {
-    override fun requestFocus(activity: Activity) {
-        val view = activity.findViewById<View>(id)
-        view.requestFocus()
+    override fun requestFocus(activity: Activity?) {
+        val view = activity?.findViewById<View>(id)
+        view?.requestFocus()
     }
 }

--- a/keyboard/src/androidLibMain/kotlin/FocusHandler.kt
+++ b/keyboard/src/androidLibMain/kotlin/FocusHandler.kt
@@ -1,0 +1,42 @@
+/*
+ Copyright 2021 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.keyboard
+
+import android.app.Activity
+import android.view.View
+import androidx.annotation.IdRes
+import androidx.compose.ui.focus.FocusRequester
+
+actual interface FocusHandler {
+    fun requestFocus(activity: Activity)
+}
+
+class ComposeFocusHandler(private val focusRequester: FocusRequester) : FocusHandler {
+    override fun requestFocus(activity: Activity) {
+        focusRequester.requestFocus()
+    }
+}
+
+class AndroidFocusHandler(
+    @IdRes private val id: Int
+) : FocusHandler {
+    override fun requestFocus(activity: Activity) {
+        val view = activity.findViewById<View>(id)
+        view.requestFocus()
+    }
+}

--- a/keyboard/src/androidLibUnitTest/kotlin/AndroidKeyboardManagerTests.kt
+++ b/keyboard/src/androidLibUnitTest/kotlin/AndroidKeyboardManagerTests.kt
@@ -17,6 +17,9 @@ import android.content.Context
 import android.os.IBinder
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.LifecycleOwner
+import com.splendo.kaluga.architecture.lifecycle.LifecycleSubscribable
 import com.splendo.kaluga.keyboard.AndroidKeyboardManagerTests.AndroidKeyboardTestContext
 import kotlinx.coroutines.CoroutineScope
 import org.mockito.ArgumentMatchers
@@ -31,10 +34,8 @@ class AndroidKeyboardManagerTests : KeyboardManagerTests<AndroidKeyboardTestCont
         private const val viewId = 1
     }
 
-
-
     inner class AndroidKeyboardTestContext(coroutineScope:CoroutineScope) : KeyboardTestContext(), CoroutineScope by coroutineScope {
-        override val focusHandler get() = AndroidFocusHandler(mockActivity, viewId)
+        override val focusHandler get() = AndroidFocusHandler(viewId)
         override lateinit var builder: KeyboardManager.Builder
 
         val mockActivity:Activity = mock(Activity::class.java)
@@ -43,6 +44,9 @@ class AndroidKeyboardManagerTests : KeyboardManagerTests<AndroidKeyboardTestCont
         var mockInputMethodManager: InputMethodManager = mock(InputMethodManager::class.java)
 
         init {
+            val mockLifecycleOwner = mock(LifecycleOwner::class.java)
+            val mockFragmentManager = mock(FragmentManager::class.java)
+
             `when`(mockActivity.getSystemService(eq(Context.INPUT_METHOD_SERVICE))).thenReturn(
                 mockInputMethodManager
             )
@@ -51,7 +55,15 @@ class AndroidKeyboardManagerTests : KeyboardManagerTests<AndroidKeyboardTestCont
             `when`(mockView.windowToken).thenReturn(mockWindowToken)
             `when`(mockInputMethodManager.isAcceptingText).thenReturn(true)
 
-            builder = KeyboardManager.Builder(mockActivity)
+            builder = KeyboardManager.Builder()
+
+            builder.subscribe(
+                LifecycleSubscribable.LifecycleManager(
+                    mockActivity,
+                    mockLifecycleOwner,
+                    mockFragmentManager
+                )
+            )
         }
     }
 

--- a/keyboard/src/commonMain/kotlin/BaseKeyboardManager.kt
+++ b/keyboard/src/commonMain/kotlin/BaseKeyboardManager.kt
@@ -18,13 +18,12 @@ Copyright 2019 Splendo Consulting B.V. The Netherlands
 
 package com.splendo.kaluga.keyboard
 
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * Common interface which handles the focus on a view.
  */
-interface FocusHandler {
-    fun requestFocus()
-}
+expect interface FocusHandler
 
 /**
  * Interface that defines the actions available for the Keyboard Manager
@@ -43,7 +42,7 @@ interface BaseKeyboardManager {
          *
          * @return The KeyboardManager object
          */
-        fun create(): BaseKeyboardManager
+        fun create(coroutineScope: CoroutineScope): BaseKeyboardManager
     }
 
     /**
@@ -68,6 +67,6 @@ expect class KeyboardManager : BaseKeyboardManager {
      * Builder for creating a [KeyboardManager].
      */
     class Builder : BaseKeyboardManager.Builder {
-        override fun create(): KeyboardManager
+        override fun create(coroutineScope: CoroutineScope): KeyboardManager
     }
 }

--- a/keyboard/src/commonTest/kotlin/KeyboardManagerTests.kt
+++ b/keyboard/src/commonTest/kotlin/KeyboardManagerTests.kt
@@ -31,7 +31,7 @@ abstract class KeyboardManagerTests<KTC : KeyboardTestContext> : UIThreadTest<KT
     @Test
     fun testShow() = testOnUIThread {
         launch {
-            val manager = builder.create()
+            val manager = builder.create(this)
             yield()
             manager.show(focusHandler)
             cancel()
@@ -45,7 +45,7 @@ abstract class KeyboardManagerTests<KTC : KeyboardTestContext> : UIThreadTest<KT
     @Test
     fun testDismiss() = testOnUIThread {
         launch {
-            val manager = builder.create()
+            val manager = builder.create(this)
             yield()
             manager.hide()
             cancel()

--- a/keyboard/src/iosMain/kotlin/FocusHandler.kt
+++ b/keyboard/src/iosMain/kotlin/FocusHandler.kt
@@ -1,0 +1,32 @@
+/*
+ Copyright 2021 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.keyboard
+
+import platform.UIKit.UIView
+
+actual interface FocusHandler {
+    fun requestFocus()
+}
+
+class UIKitFocusHandler(val view: UIView) : FocusHandler {
+    override fun requestFocus() {
+        if (view.canBecomeFirstResponder) {
+            view.becomeFirstResponder()
+        }
+    }
+}

--- a/keyboard/src/iosMain/kotlin/KeyboardManager.kt
+++ b/keyboard/src/iosMain/kotlin/KeyboardManager.kt
@@ -18,22 +18,14 @@ Copyright 2019 Splendo Consulting B.V. The Netherlands
 
 package com.splendo.kaluga.keyboard
 
+import kotlinx.coroutines.CoroutineScope
 import platform.UIKit.UIApplication
-import platform.UIKit.UIView
 import platform.darwin.sel_registerName
-
-class UIKitFocusHandler(val view: UIView) : FocusHandler {
-    override fun requestFocus() {
-        if (view.canBecomeFirstResponder) {
-            view.becomeFirstResponder()
-        }
-    }
-}
 
 actual class KeyboardManager(private val application: UIApplication) : BaseKeyboardManager {
 
     actual class Builder(private val application: UIApplication = UIApplication.sharedApplication) : BaseKeyboardManager.Builder {
-        actual override fun create() = KeyboardManager(application)
+        actual override fun create(coroutineScope: CoroutineScope) = KeyboardManager(application)
     }
 
     override fun show(focusHandler: FocusHandler) {

--- a/keyboard/src/jsMain/kotlin/FocusHandler.kt
+++ b/keyboard/src/jsMain/kotlin/FocusHandler.kt
@@ -1,0 +1,20 @@
+/*
+ Copyright 2021 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.keyboard
+
+actual interface FocusHandler

--- a/keyboard/src/jsMain/kotlin/KeyboardManager.kt
+++ b/keyboard/src/jsMain/kotlin/KeyboardManager.kt
@@ -18,10 +18,12 @@ Copyright 2019 Splendo Consulting B.V. The Netherlands
 
 package com.splendo.kaluga.keyboard
 
+import kotlinx.coroutines.CoroutineScope
+
 actual class KeyboardManager : BaseKeyboardManager {
 
     actual class Builder : BaseKeyboardManager.Builder {
-        actual override fun create() = KeyboardManager()
+        actual override fun create(coroutineScope: CoroutineScope) = KeyboardManager()
     }
 
     override fun show(focusHandler: FocusHandler) {

--- a/keyboard/src/jvmMain/kotlin/FocusHandler.kt
+++ b/keyboard/src/jvmMain/kotlin/FocusHandler.kt
@@ -1,0 +1,20 @@
+/*
+ Copyright 2021 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.keyboard
+
+actual interface FocusHandler

--- a/keyboard/src/jvmMain/kotlin/KeyboardManager.kt
+++ b/keyboard/src/jvmMain/kotlin/KeyboardManager.kt
@@ -18,10 +18,12 @@ Copyright 2019 Splendo Consulting B.V. The Netherlands
 
 package com.splendo.kaluga.keyboard
 
+import kotlinx.coroutines.CoroutineScope
+
 actual class KeyboardManager : BaseKeyboardManager {
 
     actual class Builder : BaseKeyboardManager.Builder {
-        actual override fun create() = KeyboardManager()
+        actual override fun create(coroutineScope: CoroutineScope) = KeyboardManager()
     }
 
     override fun show(focusHandler: FocusHandler) {

--- a/test-utils/src/commonMain/kotlin/mock/keyboard/MockKeyboardManager.kt
+++ b/test-utils/src/commonMain/kotlin/mock/keyboard/MockKeyboardManager.kt
@@ -19,6 +19,7 @@ package com.splendo.kaluga.test.mock.keyboard
 
 import com.splendo.kaluga.keyboard.BaseKeyboardManager
 import com.splendo.kaluga.keyboard.FocusHandler
+import kotlinx.coroutines.CoroutineScope
 
 class MockKeyboardManager : BaseKeyboardManager {
 
@@ -26,7 +27,7 @@ class MockKeyboardManager : BaseKeyboardManager {
 
         val builtKeyboardManagers = mutableListOf<MockKeyboardManager>()
 
-        override fun create(): MockKeyboardManager {
+        override fun create(coroutineScope: CoroutineScope): MockKeyboardManager {
             return MockKeyboardManager().also { builtKeyboardManagers.add(it) }
         }
     }


### PR DESCRIPTION
Fixes bug in #293 if `KeyboardManager` holds an activity that has already been destroyed. Made `FocusRequester` an `expect` interface.