### PR TITLE
#311 Handle INDICATE Property

### DIFF
--- a/bluetooth/src/androidLibMain/kotlin/Characteristic.kt
+++ b/bluetooth/src/androidLibMain/kotlin/Characteristic.kt
@@ -40,6 +40,8 @@ actual interface CharacteristicWrapper {
     fun intValue(formatType: Int, offset: Int): Int
 }
 
+fun CharacteristicWrapper.hasProperty(property: Int) = properties and property != 0
+
 class DefaultCharacteristicWrapper(private val gattCharacteristic: BluetoothGattCharacteristic) : CharacteristicWrapper {
 
     override val uuid: java.util.UUID

--- a/bluetooth/src/androidLibMain/kotlin/Characteristic.kt
+++ b/bluetooth/src/androidLibMain/kotlin/Characteristic.kt
@@ -40,7 +40,7 @@ actual interface CharacteristicWrapper {
     fun intValue(formatType: Int, offset: Int): Int
 }
 
-fun CharacteristicWrapper.hasProperty(property: Int) = properties and property != 0
+fun CharacteristicWrapper.hasProperty(property: Int) = properties.and(property) == property
 
 class DefaultCharacteristicWrapper(private val gattCharacteristic: BluetoothGattCharacteristic) : CharacteristicWrapper {
 

--- a/bluetooth/src/androidLibMain/kotlin/Characteristic.kt
+++ b/bluetooth/src/androidLibMain/kotlin/Characteristic.kt
@@ -39,8 +39,7 @@ actual interface CharacteristicWrapper {
     fun floatValue(formatType: Int, offset: Int): Float
     fun intValue(formatType: Int, offset: Int): Int
 }
-
-fun CharacteristicWrapper.hasProperty(property: Int) = properties.and(property) == property
+fun CharacteristicWrapper.containsAnyOf(vararg property: Int) = properties and property.reduce { acc, i -> acc.or(i) } != 0
 
 class DefaultCharacteristicWrapper(private val gattCharacteristic: BluetoothGattCharacteristic) : CharacteristicWrapper {
 

--- a/bluetooth/src/androidLibMain/kotlin/Characteristic.kt
+++ b/bluetooth/src/androidLibMain/kotlin/Characteristic.kt
@@ -39,7 +39,12 @@ actual interface CharacteristicWrapper {
     fun floatValue(formatType: Int, offset: Int): Float
     fun intValue(formatType: Int, offset: Int): Int
 }
-fun CharacteristicWrapper.containsAnyOf(vararg property: Int) = properties and property.reduce { acc, i -> acc.or(i) } != 0
+
+fun CharacteristicWrapper.containsAnyOf(vararg property: Int) =
+    if (property.count() > 0)
+        properties and property.reduce { acc, i -> acc.or(i) } != 0
+    else
+        false
 
 class DefaultCharacteristicWrapper(private val gattCharacteristic: BluetoothGattCharacteristic) : CharacteristicWrapper {
 

--- a/bluetooth/src/androidLibMain/kotlin/device/DeviceConnectionManager.kt
+++ b/bluetooth/src/androidLibMain/kotlin/device/DeviceConnectionManager.kt
@@ -206,8 +206,8 @@ internal actual class DeviceConnectionManager(
                 }
 
                 val value = when {
-                    action.enable and action.characteristic.wrapper.hasProperty(PROPERTY_INDICATE) -> BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
-                    action.enable and action.characteristic.wrapper.hasProperty(PROPERTY_NOTIFY) -> BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                    action.enable && action.characteristic.wrapper.hasProperty(PROPERTY_NOTIFY) -> BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                    action.enable && action.characteristic.wrapper.hasProperty(PROPERTY_INDICATE) -> BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
                     else -> BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
                 }
 

--- a/bluetooth/src/androidLibMain/kotlin/device/DeviceConnectionManager.kt
+++ b/bluetooth/src/androidLibMain/kotlin/device/DeviceConnectionManager.kt
@@ -30,7 +30,7 @@ import com.splendo.kaluga.base.ApplicationHolder
 import com.splendo.kaluga.base.utils.toHexString
 import com.splendo.kaluga.bluetooth.DefaultGattServiceWrapper
 import com.splendo.kaluga.bluetooth.Service
-import com.splendo.kaluga.bluetooth.hasProperty
+import com.splendo.kaluga.bluetooth.containsAnyOf
 import com.splendo.kaluga.bluetooth.uuidString
 import com.splendo.kaluga.logging.info
 import com.splendo.kaluga.logging.warn
@@ -202,9 +202,9 @@ internal actual class DeviceConnectionManager(
                 }
 
                 when {
-                    action.enable && action.characteristic.wrapper.hasProperty(PROPERTY_NOTIFY) -> BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
-                    action.enable && action.characteristic.wrapper.hasProperty(PROPERTY_INDICATE) -> BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
-                    !action.enable && action.characteristic.wrapper.hasProperty(PROPERTY_INDICATE or PROPERTY_NOTIFY) -> BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
+                    action.enable && action.characteristic.wrapper.containsAnyOf(PROPERTY_NOTIFY) -> BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                    action.enable && action.characteristic.wrapper.containsAnyOf(PROPERTY_INDICATE) -> BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
+                    !action.enable && action.characteristic.wrapper.containsAnyOf(PROPERTY_INDICATE, PROPERTY_NOTIFY) -> BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
                     else -> {
                         warn(TAG, "(${action.characteristic.uuid.uuidString}) Failed attempt to perform notification action. neither NOTIFICATION nor INDICATION is supported. Supported properties: ${action.characteristic.wrapper.properties}")
                         null

--- a/bluetooth/src/androidLibMain/kotlin/device/DeviceConnectionManager.kt
+++ b/bluetooth/src/androidLibMain/kotlin/device/DeviceConnectionManager.kt
@@ -205,7 +205,6 @@ internal actual class DeviceConnectionManager(
                     info(TAG, "setCharacteristicNotification result: $it")
                 }
 
-                info { " * wrapper property: ${action.characteristic.wrapper.properties}" }
                 val value = when {
                     action.enable and action.characteristic.wrapper.hasProperty(PROPERTY_INDICATE) -> BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
                     action.enable and action.characteristic.wrapper.hasProperty(PROPERTY_NOTIFY) -> BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE

--- a/bluetooth/src/androidLibMain/kotlin/device/DeviceConnectionManager.kt
+++ b/bluetooth/src/androidLibMain/kotlin/device/DeviceConnectionManager.kt
@@ -86,11 +86,6 @@ internal actual class DeviceConnectionManager(
             characteristic ?: return
 
             updateCharacteristic(characteristic)
-
-            //TODO: Remove it before merge to master
-            // if (characteristic.properties and PROPERTY_INDICATE != 0) {
-            //     gatt?.readCharacteristic(characteristic)
-            // }
         }
 
         override fun onServicesDiscovered(gatt: BluetoothGatt?, status: Int) {

--- a/bluetooth/src/androidLibMain/kotlin/device/DeviceConnectionManager.kt
+++ b/bluetooth/src/androidLibMain/kotlin/device/DeviceConnectionManager.kt
@@ -22,6 +22,7 @@ import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCallback
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattCharacteristic.PROPERTY_INDICATE
+import android.bluetooth.BluetoothGattCharacteristic.PROPERTY_NOTIFY
 import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothProfile
 import android.content.Context
@@ -205,11 +206,11 @@ internal actual class DeviceConnectionManager(
                 }
 
                 info { " * wrapper property: ${action.characteristic.wrapper.properties}" }
-                val value = if (action.enable)
-                    if (action.characteristic.wrapper.hasProperty(PROPERTY_INDICATE))
-                        BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
-                    else BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
-                else BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
+                val value = when {
+                    action.enable and action.characteristic.wrapper.hasProperty(PROPERTY_INDICATE) -> BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
+                    action.enable and action.characteristic.wrapper.hasProperty(PROPERTY_NOTIFY) -> BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                    else -> BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
+                }
 
                 action.characteristic.descriptors.forEach { descriptor ->
                     info(TAG, "(${action.characteristic.uuid.uuidString}) writeValue 0x${value.toHexString()} to $descriptor")

--- a/bluetooth/src/androidLibMain/kotlin/device/DeviceConnectionManager.kt
+++ b/bluetooth/src/androidLibMain/kotlin/device/DeviceConnectionManager.kt
@@ -33,6 +33,7 @@ import com.splendo.kaluga.bluetooth.Service
 import com.splendo.kaluga.bluetooth.hasProperty
 import com.splendo.kaluga.bluetooth.uuidString
 import com.splendo.kaluga.logging.info
+import com.splendo.kaluga.logging.warn
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -209,7 +210,10 @@ internal actual class DeviceConnectionManager(
                     action.enable && action.characteristic.wrapper.hasProperty(PROPERTY_NOTIFY) -> BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
                     action.enable && action.characteristic.wrapper.hasProperty(PROPERTY_INDICATE) -> BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
                     !action.enable && action.characteristic.wrapper.hasProperty(PROPERTY_INDICATE or PROPERTY_NOTIFY) -> BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
-                    else -> null
+                    else -> {
+                        warn(TAG, "(${action.characteristic.uuid.uuidString}) Failed attempt to perform notification action. neither NOTIFICATION nor INDICATION is supported. Supported properties: ${action.characteristic.wrapper.properties}")
+                        null
+                    }
                 }?.let { value ->
                     action.characteristic.descriptors.forEach { descriptor ->
                         info(TAG, "(${action.characteristic.uuid.uuidString}) writeValue 0x${value.toHexString()} to $descriptor")


### PR DESCRIPTION
It seems to be the only change needed to add INDICATE support, but for some reason, it doesn't fix our problem in Whipr. I'm trying to figure out where is the issue: in Kaluga or Whipr.

Looks like observing one characteristic lock observing another so I assume that in Action handling something goes wrong.

Current problem:

We have three characteristics in the same service: **FTMS Point Control**, **FTMS Status** and **Rower data**. **FTMS Status** and **Rower data** are available for NOTIFY, **FTMS  Point Control** for WRITE and INDICATE. 
On a setup screen, we are using only   **Point Control** on the next (workout) screen all three characteristics.

If I  subscribe or **FTMS  Point Control** indication, on the next scene I receive **Rower data**, but not **FTMS Status**.
If I don't subscribe on **FTMS  Point Control** on the first screen, I receive **FTMS Status** but not **Rower data**,