### PR TITLE
 Makes NetworkStateRepo class open, so mocks can be written

### DIFF
--- a/system/src/commonMain/kotlin/com/splendo/kaluga/system/network/state/NetworkStateRepo.kt
+++ b/system/src/commonMain/kotlin/com/splendo/kaluga/system/network/state/NetworkStateRepo.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
-class NetworkStateRepo(
+open class NetworkStateRepo(
     private val networkManagerBuilder: BaseNetworkManager.Builder,
 ) : ColdStateRepo<NetworkState>() {
 
@@ -79,7 +79,7 @@ class NetworkStateRepo(
         }
     }
 
-    internal fun onNetworkStateChange(network: Network) {
+    protected fun onNetworkStateChange(network: Network) {
         runBlocking {
             takeAndChangeState { state: NetworkState ->
                 when (state) {


### PR DESCRIPTION
Somehow related to #208: ahead of creating a test-utils-system module, this class should be open or have an interface to allow mocking.
Chose the former, for convenience of how the mock should have worked on a separate project