### PR TITLE
Beacon timeout algorithm stricter check.

### DIFF
--- a/beacons/src/commonMain/kotlin/Beacons.kt
+++ b/beacons/src/commonMain/kotlin/Beacons.kt
@@ -95,7 +95,7 @@ class Beacons(
             }
             cache[beacon.beaconID] = beacon to coroutineScope.launch {
                 debug(TAG, "[Added] $beacon")
-                delay(timeoutMs)
+                delay(beacon.lastSeen.millisecondSinceEpoch + timeoutMs - Date.now().millisecondSinceEpoch)
                 debug(TAG, "[Lost] $beacon")
                 cache.remove(beacon.beaconID)
                 updateList()


### PR DESCRIPTION
#487

I added the lastSeen of each beacon to the timeout as an extra check to solve this. That means timeout can now give negative values for those elements and they will instantly be ignored. 
