### PR TITLE
Solves #500 Android / iOS scanner inconsistencies

### DIFF
--- a/bluetooth/README.md
+++ b/bluetooth/README.md
@@ -94,6 +94,6 @@ class CommonViewModel(bltBuilder: BluetoothBuilder) : BaseViewModel() {
 ```
 
 ### Notes
-There is a major difference when it comes to default reported device emissions between Android and iOS. Android will report multiple emissions of the same device, as iOS will filter them out.
+There is a major difference when it comes to the reporting of scanned devices between Android and iOS. Android report multiple scans of the same device, whereas iOS filters them out.
 
 To align the behaviour across platform the [CBCentralManagerScanOptionAllowDuplicatesKey](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerscanoptionallowduplicateskey) option is enabled on iOS.

--- a/bluetooth/README.md
+++ b/bluetooth/README.md
@@ -43,7 +43,7 @@ bluetooth.devices()[someUUID].disconnect()
 ### Android
 You may notice that when you ask for kaluga's `Permission.Bluetooth` the android request alert will prompt `Location` permission. This behaviour is encountered because Android system requires Location to access the hardware identifiers of nearby external devices via Bluetooth.
 
-In order to setup a bluetooth repo on android you need to do the following:
+In order to setup a bluetooth repo you need to do the following:
 ```kotlin
 // Somewhere in Android code
 val permissions = Permissions(
@@ -53,7 +53,30 @@ val permissions = Permissions(
     }
 )
 
+val scanSettings = ScanSettings.Builder()
+    .setScanMode(..)
+    .setNumOfMatches(..)
+    .build()
+
+val scannerBuilder = Scanner.Builder(scanSettings = scanSettings,..)
+
 val bluetoothBuilder = BluetoothBuilder(permissions = permissions)
+CommonViewModel(bluetoothBuilder)
+...
+
+// Somewhere in iOS code
+val permissions = Permissions(
+    PermissionsBuilder().apply {
+        registerBluetoothPermission()
+        registerLocationPermission()
+    }
+)
+
+val scanSettings = ScanSettings(allowDuplicateKeys, solicitedServiceUUIDsKey)
+
+val scannerBuilder = Scanner.Builder(scanSettings)
+
+val bluetoothBuilder = BluetoothBuilder(permissions = permissions, scannerBuilder = scannerBuilder)
 CommonViewModel(bluetoothBuilder)
 ...
 
@@ -71,6 +94,4 @@ class CommonViewModel(bltBuilder: BluetoothBuilder) : BaseViewModel() {
 ### Notes
 There is a major difference when it comes to default reported device emissions between Android and iOS. Android will report multiple emissions of the same device, as iOS will filter them out.
 
-To make the API consistent between both platforms under the hood, we enable for iOS the [CBCentralManagerScanOptionAllowDuplicatesKey](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerscanoptionallowduplicateskey) option (which is disabled by default).
-
-In most cases (like observing the distance to a beacon) this behavior satisfies both platform needs. In the future, we will provide a common API that allows customization of the emission behavior.
+To align the behaviour across platform the [CBCentralManagerScanOptionAllowDuplicatesKey](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerscanoptionallowduplicateskey) option is enabled on iOS.

--- a/bluetooth/README.md
+++ b/bluetooth/README.md
@@ -67,3 +67,10 @@ class CommonViewModel(bltBuilder: BluetoothBuilder) : BaseViewModel() {
     )
 } 
 ```
+
+### Notes
+There is a major difference when it comes to default reported device emissions between Android and iOS. Android will report multiple emissions of the same device, as iOS will filter them out.
+
+To make the API consistent between both platforms under the hood, we enable for iOS the [CBCentralManagerScanOptionAllowDuplicatesKey](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerscanoptionallowduplicateskey) option (which is disabled by default).
+
+In most cases (like observing the distance to a beacon) this behavior satisfies both platform needs. In the future, we will provide a common API that allows customization of the emission behavior.

--- a/bluetooth/README.md
+++ b/bluetooth/README.md
@@ -96,4 +96,4 @@ class CommonViewModel(bltBuilder: BluetoothBuilder) : BaseViewModel() {
 ### Notes
 There is a major difference when it comes to the reporting of scanned devices between Android and iOS. Android report multiple scans of the same device, whereas iOS filters them out.
 
-To align the behaviour across platform the [CBCentralManagerScanOptionAllowDuplicatesKey](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerscanoptionallowduplicateskey) option is enabled on iOS.
+To align the behaviour across platforms the [CBCentralManagerScanOptionAllowDuplicatesKey](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerscanoptionallowduplicateskey) option is enabled on iOS. It can be set to another value using `ScanSettings` as shown above.

--- a/bluetooth/README.md
+++ b/bluetooth/README.md
@@ -43,7 +43,9 @@ bluetooth.devices()[someUUID].disconnect()
 ### Android
 You may notice that when you ask for kaluga's `Permission.Bluetooth` the android request alert will prompt `Location` permission. This behaviour is encountered because Android system requires Location to access the hardware identifiers of nearby external devices via Bluetooth.
 
+### Setup
 In order to setup a bluetooth repo you need to do the following:
+
 ```kotlin
 // Somewhere in Android code
 val permissions = Permissions(

--- a/bluetooth/src/androidLibMain/kotlin/scanner/Scanner.kt
+++ b/bluetooth/src/androidLibMain/kotlin/scanner/Scanner.kt
@@ -50,10 +50,10 @@ import no.nordicsemi.android.support.v18.scanner.ScanResult
 import no.nordicsemi.android.support.v18.scanner.ScanSettings
 
 actual class Scanner internal constructor(
-    private val bluetoothScanner: BluetoothLeScannerCompat = BluetoothLeScannerCompat.getScanner(),
-    private val bluetoothAdapter: BluetoothAdapter? = BluetoothAdapter.getDefaultAdapter(),
-    private val scanSettings: ScanSettings = defaultScanSettings,
-    private val applicationContext: Context = ApplicationHolder.applicationContext,
+    private val applicationContext: Context,
+    private val bluetoothScanner: BluetoothLeScannerCompat,
+    private val bluetoothAdapter: BluetoothAdapter?,
+    private val scanSettings: ScanSettings,
     permissions: Permissions,
     connectionSettings: ConnectionSettings,
     autoRequestPermission: Boolean,
@@ -62,11 +62,10 @@ actual class Scanner internal constructor(
 ) : BaseScanner(permissions, connectionSettings, autoRequestPermission, autoEnableSensors, stateRepo) {
 
     class Builder(
-        private val bluetoothScanner: BluetoothLeScannerCompat = BluetoothLeScannerCompat.getScanner(),
-        private val bluetoothAdapter: BluetoothAdapter? =
-            (ApplicationHolder.applicationContext.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager).adapter,
-        private val scanSettings: ScanSettings = defaultScanSettings,
         private val applicationContext: Context = ApplicationHolder.applicationContext,
+        private val bluetoothScanner: BluetoothLeScannerCompat = BluetoothLeScannerCompat.getScanner(),
+        private val bluetoothAdapter: BluetoothAdapter? = (applicationContext.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager).adapter,
+        private val scanSettings: ScanSettings = defaultScanSettings,
     ) : BaseScanner.Builder {
 
         override fun create(
@@ -76,7 +75,7 @@ actual class Scanner internal constructor(
             autoEnableSensors: Boolean,
             scanningStateRepo: StateRepo<ScanningState, MutableStateFlow<ScanningState>>,
         ): BaseScanner {
-            return Scanner(bluetoothScanner, bluetoothAdapter, scanSettings, applicationContext, permissions, connectionSettings, autoRequestPermission, autoEnableSensors, scanningStateRepo)
+            return Scanner(applicationContext, bluetoothScanner, bluetoothAdapter, scanSettings, permissions, connectionSettings, autoRequestPermission, autoEnableSensors, scanningStateRepo)
         }
     }
 

--- a/bluetooth/src/androidLibMain/kotlin/scanner/Scanner.kt
+++ b/bluetooth/src/androidLibMain/kotlin/scanner/Scanner.kt
@@ -18,6 +18,7 @@
 package com.splendo.kaluga.bluetooth.scanner
 
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.os.ParcelUuid
 import co.touchlab.stately.concurrency.AtomicReference
@@ -62,7 +63,8 @@ actual class Scanner internal constructor(
 
     class Builder(
         private val bluetoothScanner: BluetoothLeScannerCompat = BluetoothLeScannerCompat.getScanner(),
-        private val bluetoothAdapter: BluetoothAdapter? = BluetoothAdapter.getDefaultAdapter(),
+        private val bluetoothAdapter: BluetoothAdapter? =
+            (ApplicationHolder.applicationContext.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager).adapter,
         private val scanSettings: ScanSettings = defaultScanSettings,
         private val applicationContext: Context = ApplicationHolder.applicationContext,
     ) : BaseScanner.Builder {

--- a/bluetooth/src/iosMain/kotlin/BluetoothBuilder.kt
+++ b/bluetooth/src/iosMain/kotlin/BluetoothBuilder.kt
@@ -14,10 +14,11 @@ actual class BluetoothBuilder(
         PermissionsBuilder(bundle).apply {
             registerBluetoothPermission()
         }
-    )
+    ),
+    private val scannerBuilder: Scanner.Builder = Scanner.Builder()
 ) : Bluetooth.Builder {
 
     override fun create(connectionSettings: ConnectionSettings, autoRequestPermission: Boolean, autoEnableBluetooth: Boolean, coroutineScope: CoroutineScope): Bluetooth {
-        return Bluetooth(permissions, connectionSettings, autoRequestPermission, autoEnableBluetooth, Scanner.Builder(), coroutineScope)
+        return Bluetooth(permissions, connectionSettings, autoRequestPermission, autoEnableBluetooth, scannerBuilder, coroutineScope)
     }
 }

--- a/bluetooth/src/iosMain/kotlin/scanner/Scanner.kt
+++ b/bluetooth/src/iosMain/kotlin/scanner/Scanner.kt
@@ -147,7 +147,7 @@ actual class Scanner internal constructor(
         awaitPoweredOn.await()
         centralManager.scanForPeripheralsWithServices(
             filter?.let { listOf(filter) },
-            scanSettings.scanOptions
+            scanSettings.parse()
         )
     }
 
@@ -201,7 +201,20 @@ actual class Scanner internal constructor(
         }
     }
 
-    class ScanSettings private constructor(val scanOptions: Map<Any?, *>) {
+    class ScanSettings private constructor(
+        private val allowDuplicateKeys: Boolean,
+        private val solicitedServiceUUIDsKey: List<UUID>?
+    ) {
+
+        fun parse(): Map<Any?, *> {
+            val result: MutableMap<String, Any> =
+                mutableMapOf(CBCentralManagerScanOptionAllowDuplicatesKey to allowDuplicateKeys)
+            solicitedServiceUUIDsKey?.let {
+                result[CBCentralManagerScanOptionSolicitedServiceUUIDsKey] = it
+            }
+            return result.toMap()
+        }
+
         data class Builder(
             // https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerscanoptionallowduplicateskey
             var allowDuplicateKeys: Boolean = true,
@@ -214,14 +227,7 @@ actual class Scanner internal constructor(
             fun solicitedServiceUUIDsKey(keys: List<UUID>) =
                 apply { solicitedServiceUUIDsKey = keys }
 
-            fun build(): ScanSettings {
-                val result: MutableMap<String, Any> =
-                    mutableMapOf(CBCentralManagerScanOptionAllowDuplicatesKey to allowDuplicateKeys)
-                solicitedServiceUUIDsKey?.let {
-                    result[CBCentralManagerScanOptionSolicitedServiceUUIDsKey] = it
-                }
-                return ScanSettings(result.toMap())
-            }
+            fun build(): ScanSettings = ScanSettings(allowDuplicateKeys, solicitedServiceUUIDsKey)
         }
     }
 }

--- a/bluetooth/src/iosMain/kotlin/scanner/Scanner.kt
+++ b/bluetooth/src/iosMain/kotlin/scanner/Scanner.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.flow.first
 import platform.CoreBluetooth.CBCentralManager
 import platform.CoreBluetooth.CBCentralManagerDelegateProtocol
 import platform.CoreBluetooth.CBCentralManagerOptionShowPowerAlertKey
+import platform.CoreBluetooth.CBCentralManagerScanOptionAllowDuplicatesKey
 import platform.CoreBluetooth.CBCentralManagerStatePoweredOn
 import platform.CoreBluetooth.CBPeripheral
 import platform.Foundation.NSError
@@ -141,7 +142,10 @@ actual class Scanner internal constructor(
         discoveringDelegates.add(delegate)
         centralManager.delegate = delegate
         awaitPoweredOn.await()
-        centralManager.scanForPeripheralsWithServices(filter?.let { listOf(filter) }, null)
+        centralManager.scanForPeripheralsWithServices(
+            filter?.let { listOf(filter) },
+            mapOf(CBCentralManagerScanOptionAllowDuplicatesKey to true)
+        )
     }
 
     override suspend fun scanForDevices(filter: Set<UUID>) =


### PR DESCRIPTION
Issue:
#500 

Desc:

Added options wrapper with default raised [CBCentralManagerScanOptionAllowDuplicatesKey](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerscanoptionallowduplicateskey) flag for iOS scanning options. 

Notes:
- Seems likes iOS scan rate is much faster than Android, fast emissions should be taken into consideration when observing results 
- Will break backwards compatibility as I had to change constructor param order
- iOS now behaves like Android by default reporting discovered device on each emission instead on start only  