### PR TITLE
KalugaDate Equatable issues on iOS

### DIFF
--- a/base/src/androidLibMain/kotlin/utils/KalugaDate.kt
+++ b/base/src/androidLibMain/kotlin/utils/KalugaDate.kt
@@ -22,7 +22,7 @@ import java.util.Date
 
 actual typealias KalugaDateHolder = Date
 
-actual class DefaultKalugaDate internal constructor(internal val calendar: Calendar) : KalugaDate {
+actual class DefaultKalugaDate internal constructor(internal val calendar: Calendar) : KalugaDate() {
 
     actual companion object {
         actual fun now(offsetInMilliseconds: Long, timeZone: TimeZone, locale: Locale): KalugaDate = DefaultKalugaDate(

--- a/base/src/commonMain/kotlin/utils/KalugaDate.kt
+++ b/base/src/commonMain/kotlin/utils/KalugaDate.kt
@@ -30,102 +30,102 @@ expect class KalugaDateHolder
  * Class describing a point in time
  * Dates are localized according to a [Locale] and relative to a given [TimeZone]
  */
-interface KalugaDate : Comparable<KalugaDate> {
+abstract class KalugaDate : Comparable<KalugaDate> {
     /**
      * The [TimeZone] in which the Date is set
      */
-    var timeZone: TimeZone
+    abstract var timeZone: TimeZone
 
     /**
      * The number of the era, e.g., AD or BC in the Julian calendar
      */
-    var era: Int
+    abstract var era: Int
 
     /**
      * The year
      */
-    var year: Int
+    abstract var year: Int
 
     /**
      * The month of the year. Starts at 1
      */
-    var month: Int
+    abstract var month: Int
 
     /**
      * The number of days in the current month
      */
-    val daysInMonth: Int
+    abstract val daysInMonth: Int
 
     /**
      * The week number within the current year.
      */
-    var weekOfYear: Int
+    abstract var weekOfYear: Int
 
     /**
      * The week number within the current month
      */
-    var weekOfMonth: Int
+    abstract var weekOfMonth: Int
 
     /**
      * The day of the current month
      */
-    var day: Int
+    abstract var day: Int
 
     /**
      * The day of the current year
      */
-    var dayOfYear: Int
+    abstract var dayOfYear: Int
 
     /**
      * The day of the week. Starts at 1
      */
-    var weekDay: Int
+    abstract var weekDay: Int
 
     /**
      * The first day of the week. E.g. Sunday in the US, Monday in France. Starts at 1.
      */
-    var firstWeekDay: Int
+    abstract var firstWeekDay: Int
 
     /**
      * The hour of the current day
      */
-    var hour: Int
+    abstract var hour: Int
 
     /**
      * The minute of the current hour
      */
-    var minute: Int
+    abstract var minute: Int
 
     /**
      * The second of the current minute
      */
-    var second: Int
+    abstract var second: Int
 
     /**
      * The millisecond of the current second
      */
-    var millisecond: Int
+    abstract var millisecond: Int
 
     /**
      * The number of milliseconds passed since epoch time (January 1st 1970 00:00:00:00 GMT)
      */
-    var millisecondSinceEpoch: Long
+    abstract var millisecondSinceEpoch: Long
 
     /**
      * Creates a copy of a [KalugaDate]
      * @return A copy of this [KalugaDate]
      */
-    fun copy(): KalugaDate
+    abstract fun copy(): KalugaDate
 
     /**
      * Returns whether this Date is in the same [timeZone] and has the same time based on [millisecondSinceEpoch]
      * @return `true` if the two dates are equal
      */
-    override fun equals(other: Any?): Boolean
+    abstract override fun equals(other: Any?): Boolean
 
-    override fun hashCode(): Int
+    abstract override fun hashCode(): Int
 
-    val date: KalugaDateHolder
+    abstract val date: KalugaDateHolder
 }
 
 expect class DefaultKalugaDate : KalugaDate {
@@ -137,7 +137,11 @@ expect class DefaultKalugaDate : KalugaDate {
          * @param locale The [Locale] for which the Date is configured. Defaults to [Locale.defaultLocale]
          * @return A [KalugaDate] relative to the current time
          */
-        fun now(offsetInMilliseconds: Long = 0L, timeZone: TimeZone = TimeZone.current(), locale: Locale = Locale.defaultLocale): KalugaDate
+        fun now(
+            offsetInMilliseconds: Long = 0L,
+            timeZone: TimeZone = TimeZone.current(),
+            locale: Locale = Locale.defaultLocale
+        ): KalugaDate
 
         /**
          * Creates a [KalugaDate] relative to January 1st 1970 00:00:00 GMT
@@ -146,11 +150,18 @@ expect class DefaultKalugaDate : KalugaDate {
          * @param locale The [Locale] for which the Date is configured. Defaults to [Locale.defaultLocale]
          * @return A [KalugaDate] relative to the current time
          */
-        fun epoch(offsetInMilliseconds: Long = 0L, timeZone: TimeZone = TimeZone.current(), locale: Locale = Locale.defaultLocale): KalugaDate
+        fun epoch(
+            offsetInMilliseconds: Long = 0L,
+            timeZone: TimeZone = TimeZone.current(),
+            locale: Locale = Locale.defaultLocale
+        ): KalugaDate
     }
 }
 
-@Deprecated("Due to name clashes with platform classes and API changes this class has been renamed and changed to an interface. It will be removed in a future release.", ReplaceWith("KalugaDate"))
+@Deprecated(
+    "Due to name clashes with platform classes and API changes this class has been renamed and changed to an interface. It will be removed in a future release.",
+    ReplaceWith("KalugaDate")
+)
 typealias Date = KalugaDate
 
 /**
@@ -181,7 +192,10 @@ operator fun KalugaDate.plus(date: KalugaDate): KalugaDate {
  * @param locale The [Locale] for which the Date is configured. Defaults to [Locale.defaultLocale]
  * @return A [KalugaDate] relative to the current time, in the UTC timezone
  */
-fun DefaultKalugaDate.Companion.nowUtc(offsetInMilliseconds: Long = 0L, locale: Locale = defaultLocale): KalugaDate =
+fun DefaultKalugaDate.Companion.nowUtc(
+    offsetInMilliseconds: Long = 0L,
+    locale: Locale = defaultLocale
+): KalugaDate =
     now(offsetInMilliseconds, TimeZone.utc, locale)
 
 /**
@@ -201,7 +215,10 @@ fun KalugaDate.toStartOfDay() = this.copy().apply {
  * @param locale The [Locale] for which the Date is configured. Defaults to [Locale.defaultLocale]
  * @return A [KalugaDate] that is set at midnight on the same day as the current time.
  */
-fun DefaultKalugaDate.Companion.today(timeZone: TimeZone = TimeZone.current(), locale: Locale = defaultLocale) = now(timeZone = timeZone, locale = locale).toStartOfDay()
+fun DefaultKalugaDate.Companion.today(
+    timeZone: TimeZone = TimeZone.current(),
+    locale: Locale = defaultLocale
+) = now(timeZone = timeZone, locale = locale).toStartOfDay()
 
 /**
  * Gets a [KalugaDate] that is set at midnight on the day after the current time.
@@ -209,7 +226,10 @@ fun DefaultKalugaDate.Companion.today(timeZone: TimeZone = TimeZone.current(), l
  * @param locale The [Locale] for which the Date is configured. Defaults to [Locale.defaultLocale]
  * @return A [KalugaDate] that is set at midnight on the day after the current time.
  */
-fun DefaultKalugaDate.Companion.tomorrow(timeZone: TimeZone = TimeZone.current(), locale: Locale = defaultLocale) = today(timeZone = timeZone, locale = locale).apply { day += 1 }
+fun DefaultKalugaDate.Companion.tomorrow(
+    timeZone: TimeZone = TimeZone.current(),
+    locale: Locale = defaultLocale
+) = today(timeZone = timeZone, locale = locale).apply { day += 1 }
 
 /**
  * Checks whether a [KalugaDate] is on the same day as a given Date.

--- a/base/src/iosMain/kotlin/utils/KalugaDate.kt
+++ b/base/src/iosMain/kotlin/utils/KalugaDate.kt
@@ -46,7 +46,7 @@ import kotlin.math.round
 
 actual typealias KalugaDateHolder = NSDate
 
-actual class DefaultKalugaDate internal constructor(private val calendar: NSCalendar, initialDate: NSDate) : KalugaDate {
+actual class DefaultKalugaDate internal constructor(private val calendar: NSCalendar, initialDate: NSDate) : KalugaDate() {
     actual companion object {
 
         const val nanoSecondPerMilliSecond = 1000 * 1000

--- a/base/src/jsMain/kotlin/utils/KalugaDate.kt
+++ b/base/src/jsMain/kotlin/utils/KalugaDate.kt
@@ -20,7 +20,7 @@ package com.splendo.kaluga.base.utils
 actual typealias KalugaDateHolder = kotlin.js.Date
 
 // TODO Implement with proper date solution for Java Script
-actual class DefaultKalugaDate internal constructor(override val date: KalugaDateHolder) : KalugaDate {
+actual class DefaultKalugaDate internal constructor(override val date: KalugaDateHolder) : KalugaDate() {
 
     actual companion object {
         actual fun now(offsetInMilliseconds: Long, timeZone: TimeZone, locale: Locale): KalugaDate = DefaultKalugaDate(kotlin.js.Date(kotlin.js.Date.now() + offsetInMilliseconds))

--- a/base/src/jvmMain/kotlin/utils/KalugaDate.kt
+++ b/base/src/jvmMain/kotlin/utils/KalugaDate.kt
@@ -22,7 +22,7 @@ import java.util.Date
 
 actual typealias KalugaDateHolder = Date
 
-actual class DefaultKalugaDate internal constructor(internal val calendar: Calendar) : KalugaDate {
+actual class DefaultKalugaDate internal constructor(internal val calendar: Calendar) : KalugaDate() {
 
     actual companion object {
         actual fun now(offsetInMilliseconds: Long, timeZone: TimeZone, locale: Locale): KalugaDate = DefaultKalugaDate(


### PR DESCRIPTION
#515 

My approach was to change the interface to abstract class as it is still handy to extend for testing and will generate an Equatable NSObject for iOS.

