### PR TITLE
Fix isConnectable flow

### DIFF
--- a/bluetooth/src/commonMain/kotlin/device/Device.kt
+++ b/bluetooth/src/commonMain/kotlin/device/Device.kt
@@ -31,9 +31,9 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
@@ -70,15 +70,12 @@ class DeviceImpl(
     private val connectionManager = CompletableDeferred<DeviceConnectionManager>()
     private val sharedInfo = MutableStateFlow(initialDeviceInfo)
     private val deviceStateRepo = MutableStateFlow<ConnectableDeviceStateFlowRepo?>(null)
-    private val isConnectable = flow {
-        val isConnectable = initialDeviceInfo.advertisementData.isConnectable
-        sharedInfo
-            .map { it.advertisementData.isConnectable }
-            .collect { value ->
-                // Once device is connectable we keep that state
-                emit(isConnectable.or(value))
-            }
-    }
+    private val isConnectable = sharedInfo
+        .map { it.advertisementData.isConnectable }
+        .runningFold(initial = initialDeviceInfo.advertisementData.isConnectable) { acc, value ->
+            // Once device is connectable we keep that state
+            acc.or(value)
+        }
     override val info: Flow<DeviceInfo> = sharedInfo.asStateFlow()
     override val state: Flow<DeviceState> = combine(
         isConnectable,

--- a/bluetooth/src/commonTest/kotlin/device/DeviceTest.kt
+++ b/bluetooth/src/commonTest/kotlin/device/DeviceTest.kt
@@ -59,6 +59,23 @@ class DeviceTest :
     }
 
     @Test
+    fun testNotConnectableToDisconnectedStateTransition() = testWithFlowAndTestContext(Configuration.DeviceWithDescriptor(advertisementData = MockAdvertisementData(isConnectable = false))) {
+        test {
+            deviceConnectionManagerBuilder.createMock.verify(rule = never())
+            assertIs<NotConnectableDeviceState>(it)
+            assertEquals(configuration.rssi, device.info.first().rssi)
+        }
+        mainAction {
+            device.advertisementDataDidUpdate(
+                MockAdvertisementData(isConnectable = true)
+            )
+        }
+        test {
+            assertIs<ConnectableDeviceState.Disconnected>(it)
+        }
+    }
+
+    @Test
     fun testConnected() = testWithFlowAndTestContext(Configuration.DeviceWithDescriptor()) {
         getDisconnectedState()
         connecting()

--- a/bluetooth/src/commonTest/kotlin/device/DeviceTest.kt
+++ b/bluetooth/src/commonTest/kotlin/device/DeviceTest.kt
@@ -25,12 +25,14 @@ import com.splendo.kaluga.test.base.mock.verify
 import com.splendo.kaluga.test.base.yieldMultiple
 import com.splendo.kaluga.test.bluetooth.device.MockAdvertisementData
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.fail
 
 class DeviceTest :
     BluetoothFlowTest<BluetoothFlowTest.Configuration.DeviceWithDescriptor, BluetoothFlowTest.DescriptorContext, DeviceState>() {
@@ -59,21 +61,61 @@ class DeviceTest :
     }
 
     @Test
-    fun testNotConnectableToDisconnectedStateTransition() = testWithFlowAndTestContext(Configuration.DeviceWithDescriptor(advertisementData = MockAdvertisementData(isConnectable = false))) {
-        test {
-            deviceConnectionManagerBuilder.createMock.verify(rule = never())
-            assertIs<NotConnectableDeviceState>(it)
-            assertEquals(configuration.rssi, device.info.first().rssi)
+    fun testNotConnectableToDisconnectedStateTransition() = try {
+        // Is not connectable initially
+        val configuration = Configuration.DeviceWithDescriptor(
+            advertisementData = MockAdvertisementData(isConnectable = false)
+        )
+        testWithFlowAndTestContext(configuration) {
+            test {
+                deviceConnectionManagerBuilder.createMock.verify(rule = never())
+                assertIs<NotConnectableDeviceState>(it)
+                assertEquals(configuration.rssi, device.info.first().rssi)
+            }
+            // 'Advertise' as connectable
+            mainAction {
+                device.advertisementDataDidUpdate(
+                    MockAdvertisementData(isConnectable = true)
+                )
+            }
+            test {
+                assertIs<ConnectableDeviceState.Disconnected>(it)
+            }
+            // 'Advertise' as not connectable
+            mainAction {
+                device.advertisementDataDidUpdate(
+                    MockAdvertisementData(isConnectable = false)
+                )
+            }
+            // State should stays [ConnectableDeviceState.Disconnected]
+            test {
+                fail("State transition shouldn't be called")
+            }
         }
-        mainAction {
-            device.advertisementDataDidUpdate(
-                MockAdvertisementData(isConnectable = true)
-            )
+    } catch (_: TimeoutCancellationException) { }
+
+    @Test
+    fun testDisconnectedStateNeverTransitionToNonConnectable() = try {
+        // Connectable initially
+        val configuration = Configuration.DeviceWithDescriptor(
+            advertisementData = MockAdvertisementData(isConnectable = true)
+        )
+        testWithFlowAndTestContext(configuration) {
+            test {
+                assertIs<ConnectableDeviceState.Disconnected>(it)
+            }
+            // 'Advertise' as not connectable anymore
+            mainAction {
+                device.advertisementDataDidUpdate(
+                    MockAdvertisementData(isConnectable = false)
+                )
+            }
+            // State should stays [ConnectableDeviceState.Disconnected]
+            test {
+                fail("State transition shouldn't be called")
+            }
         }
-        test {
-            assertIs<ConnectableDeviceState.Disconnected>(it)
-        }
-    }
+    } catch (_: TimeoutCancellationException) { }
 
     @Test
     fun testConnected() = testWithFlowAndTestContext(Configuration.DeviceWithDescriptor()) {


### PR DESCRIPTION
Here is WIP of device state split into connectable and non connectable.
Some issues with iOS and Polar devices (probably more devices have same issues).
Once device stated connecting (also when it's already connected) it begin advertise isConnectable = false, which switches device state into non connectable.

On Android we relay on isConnectable() method inside ScanResult, which actually `(eventType & ET_CONNECTABLE_MASK) != 0`
While on iOS we relay on advertisement data dictionary.

Here is possible solution: keep is connectable flag when it's true (not resetting to false even it's advertised like that).
Another way to check is connectable on iOS maybe by checking advertisement data it self (if it's not empty, it's connectable)