### PR TITLE
Media iOS Improvements

### DIFF
--- a/example/ios/Demo/Info.plist
+++ b/example/ios/Demo/Info.plist
@@ -33,15 +33,13 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-    <key>NSBluetoothAlwaysUsageDescription</key>
-    <string>Demonstrate usage of Kaluga library</string>
-    <key>NSBluetoothPeripheralUsageDescription</key>
-    <string>Demonstrate usage of Kaluga library</string>
-	<key>NSCalendarsUsageDescription</key>
+	<key>NSAppleMusicUsageDescription</key>
 	<string>Demonstrate usage of Kaluga library</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Demonstrate usage of Kaluga library</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Demonstrate usage of Kaluga library</string>
+	<key>NSCalendarsUsageDescription</key>
 	<string>Demonstrate usage of Kaluga library</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Demonstrate usage of Kaluga library</string>
@@ -57,8 +55,10 @@
 	<string>Demonstrate usage of Kaluga library</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Demonstrate usage of Kaluga library</string>
-    <key>NSAppleMusicUsageDescription</key>
-    <string>Demonstrate usage of Kaluga library</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/example/ios/Demo/Media/MediaViewController.swift
+++ b/example/ios/Demo/Media/MediaViewController.swift
@@ -178,7 +178,7 @@ extension MediaViewController: MPMediaPickerControllerDelegate {
         if !mediaItemCollection.items.isEmpty {
             let item = mediaItemCollection.items[0]
             if let url = item.value(forProperty: MPMediaItemPropertyAssetURL) as? NSURL {
-                viewModel.didSelectFileAt(source: MediaSource.URL(url: url as URL))
+                viewModel.didSelectFileAt(source: MediaSource.URL(url: url as URL, options: [MediaSource.URLOptionsPreferPreciseDurationAndTiming(isPreferred: true)]))
             } else {
                 viewModel.didSelectFileAt(source: nil)
             }

--- a/example/ios/Demo/Media/MediaViewController.swift
+++ b/example/ios/Demo/Media/MediaViewController.swift
@@ -178,7 +178,7 @@ extension MediaViewController: MPMediaPickerControllerDelegate {
         if !mediaItemCollection.items.isEmpty {
             let item = mediaItemCollection.items[0]
             if let url = item.value(forProperty: MPMediaItemPropertyAssetURL) as? NSURL {
-                viewModel.didSelectFileAt(source: MediaSource.URL(url: url as URL, options: [MediaSource.URLOptionsPreferPreciseDurationAndTiming(isPreferred: true)]))
+                viewModel.didSelectFileAt(source: MediaSource.URL(url: url as URL, options: [MediaSource.URLOptionPreferPreciseDurationAndTiming(isPreferred: true)]))
             } else {
                 viewModel.didSelectFileAt(source: nil)
             }

--- a/example/ios/Demo/Media/MediaViewController.swift
+++ b/example/ios/Demo/Media/MediaViewController.swift
@@ -46,7 +46,7 @@ class MediaViewController: UIViewController {
     
     private lazy var viewModel = MediaViewModel(
         mediaSurfaceProvider: mediaSurfaceProvider,
-        builder: DefaultMediaManager.Builder(),
+        builder: DefaultMediaManager.Builder(settings: DefaultMediaManager.Settings(playInBackground: true, playAfterDeviceUnavailable: true)),
         alertPresenterBuilder: AlertPresenter.Builder(viewController: self),
         navigator: navigator
     )

--- a/example/shared/src/commonMain/kotlin/com/splendo/kaluga/example/shared/viewmodel/datetime/TimerViewModel.kt
+++ b/example/shared/src/commonMain/kotlin/com/splendo/kaluga/example/shared/viewmodel/datetime/TimerViewModel.kt
@@ -20,16 +20,13 @@ package com.splendo.kaluga.example.shared.viewmodel.datetime
 import com.splendo.kaluga.alerts.Alert
 import com.splendo.kaluga.alerts.AlertPresenter
 import com.splendo.kaluga.alerts.buildActionSheet
-import com.splendo.kaluga.alerts.buildAlert
 import com.splendo.kaluga.architecture.observable.toInitializedObservable
 import com.splendo.kaluga.architecture.viewmodel.BaseLifecycleViewModel
 import com.splendo.kaluga.base.text.DateFormatStyle
 import com.splendo.kaluga.base.text.KalugaDateFormatter
 import com.splendo.kaluga.base.utils.DefaultKalugaDate
-import com.splendo.kaluga.base.utils.KalugaDate
 import com.splendo.kaluga.base.utils.KalugaTimeZone
 import com.splendo.kaluga.base.utils.TimeZoneNameStyle
-import com.splendo.kaluga.base.utils.utc
 import com.splendo.kaluga.datetime.timer.RecurringTimer
 import com.splendo.kaluga.datetime.timer.Timer
 import com.splendo.kaluga.datetime.timer.elapsed
@@ -83,7 +80,7 @@ class TimerViewModel(private val alertPresenterBuilder: AlertPresenter.Builder) 
                 emit(Unit)
                 delay(100)
             }
-        }
+        },
     ) { format, _ ->
         format.format(DefaultKalugaDate.now())
     }.toInitializedObservable("", coroutineScope)

--- a/media/api/androidLib/media.api
+++ b/media/api/androidLib/media.api
@@ -18,6 +18,7 @@ public abstract class com/splendo/kaluga/media/BaseMediaManager : com/splendo/ka
 	protected abstract fun handleCreatePlayableMedia (Lcom/splendo/kaluga/media/MediaSource;)Lcom/splendo/kaluga/media/PlayableMedia;
 	protected fun handleError (Lcom/splendo/kaluga/media/PlaybackError;)V
 	protected fun handlePrepared (Lcom/splendo/kaluga/media/PlayableMedia;)V
+	protected fun handleRateChanged (F)V
 	protected abstract fun handleReset ()V
 	protected fun handleSeekCompleted (Z)V
 	public final fun reset ()V
@@ -116,6 +117,17 @@ public final class com/splendo/kaluga/media/MediaManager$Event$DidPrepare : com/
 	public static synthetic fun copy$default (Lcom/splendo/kaluga/media/MediaManager$Event$DidPrepare;Lcom/splendo/kaluga/media/PlayableMedia;ILjava/lang/Object;)Lcom/splendo/kaluga/media/MediaManager$Event$DidPrepare;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPlayableMedia ()Lcom/splendo/kaluga/media/PlayableMedia;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/splendo/kaluga/media/MediaManager$Event$RateDidChange : com/splendo/kaluga/media/MediaManager$Event {
+	public fun <init> (F)V
+	public final fun component1 ()F
+	public final fun copy (F)Lcom/splendo/kaluga/media/MediaManager$Event$RateDidChange;
+	public static synthetic fun copy$default (Lcom/splendo/kaluga/media/MediaManager$Event$RateDidChange;FILjava/lang/Object;)Lcom/splendo/kaluga/media/MediaManager$Event$RateDidChange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNewRate ()F
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -335,6 +347,10 @@ public final class com/splendo/kaluga/media/PlaybackError$PlaybackHasEnded : com
 
 public final class com/splendo/kaluga/media/PlaybackError$TimedOut : com/splendo/kaluga/media/PlaybackError {
 	public static final field INSTANCE Lcom/splendo/kaluga/media/PlaybackError$TimedOut;
+}
+
+public final class com/splendo/kaluga/media/PlaybackError$Uninitalized : com/splendo/kaluga/media/PlaybackError {
+	public static final field INSTANCE Lcom/splendo/kaluga/media/PlaybackError$Uninitalized;
 }
 
 public final class com/splendo/kaluga/media/PlaybackError$Unknown : com/splendo/kaluga/media/PlaybackError {

--- a/media/api/androidLib/media.api
+++ b/media/api/androidLib/media.api
@@ -453,9 +453,12 @@ public final class com/splendo/kaluga/media/PlaybackState$LoopMode$NotLooping : 
 
 public abstract interface class com/splendo/kaluga/media/PlaybackState$Paused : com/splendo/kaluga/media/PlaybackState$Started {
 	public abstract fun getPlay ()Lkotlin/jvm/functions/Function1;
+	public abstract fun playWithUpdatedPlaybackParameters (Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;)Lkotlin/jvm/functions/Function1;
+	public abstract fun updatePlaybackParameters (Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;)Lkotlin/jvm/functions/Function1;
 }
 
 public final class com/splendo/kaluga/media/PlaybackState$Paused$DefaultImpls {
+	public static fun playWithUpdatedPlaybackParameters (Lcom/splendo/kaluga/media/PlaybackState$Paused;Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;)Lkotlin/jvm/functions/Function1;
 	public static fun remain (Lcom/splendo/kaluga/media/PlaybackState$Paused;)Lkotlin/jvm/functions/Function1;
 }
 
@@ -477,6 +480,7 @@ public final class com/splendo/kaluga/media/PlaybackState$PlaybackParameters {
 public abstract interface class com/splendo/kaluga/media/PlaybackState$Playing : com/splendo/kaluga/media/PlaybackState$PlayingOrCompleted, com/splendo/kaluga/media/PlaybackState$Started {
 	public abstract fun getCompletedLoop ()Lkotlin/jvm/functions/Function1;
 	public abstract fun getPause ()Lkotlin/jvm/functions/Function1;
+	public abstract fun updatePlaybackParameters (Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;)Lkotlin/jvm/functions/Function1;
 }
 
 public final class com/splendo/kaluga/media/PlaybackState$Playing$DefaultImpls {

--- a/media/api/jvm/media.api
+++ b/media/api/jvm/media.api
@@ -397,9 +397,12 @@ public final class com/splendo/kaluga/media/PlaybackState$LoopMode$NotLooping : 
 
 public abstract interface class com/splendo/kaluga/media/PlaybackState$Paused : com/splendo/kaluga/media/PlaybackState$Started {
 	public abstract fun getPlay ()Lkotlin/jvm/functions/Function1;
+	public abstract fun playWithUpdatedPlaybackParameters (Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;)Lkotlin/jvm/functions/Function1;
+	public abstract fun updatePlaybackParameters (Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;)Lkotlin/jvm/functions/Function1;
 }
 
 public final class com/splendo/kaluga/media/PlaybackState$Paused$DefaultImpls {
+	public static fun playWithUpdatedPlaybackParameters (Lcom/splendo/kaluga/media/PlaybackState$Paused;Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;)Lkotlin/jvm/functions/Function1;
 	public static fun remain (Lcom/splendo/kaluga/media/PlaybackState$Paused;)Lkotlin/jvm/functions/Function1;
 }
 
@@ -421,6 +424,7 @@ public final class com/splendo/kaluga/media/PlaybackState$PlaybackParameters {
 public abstract interface class com/splendo/kaluga/media/PlaybackState$Playing : com/splendo/kaluga/media/PlaybackState$PlayingOrCompleted, com/splendo/kaluga/media/PlaybackState$Started {
 	public abstract fun getCompletedLoop ()Lkotlin/jvm/functions/Function1;
 	public abstract fun getPause ()Lkotlin/jvm/functions/Function1;
+	public abstract fun updatePlaybackParameters (Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;)Lkotlin/jvm/functions/Function1;
 }
 
 public final class com/splendo/kaluga/media/PlaybackState$Playing$DefaultImpls {

--- a/media/api/jvm/media.api
+++ b/media/api/jvm/media.api
@@ -9,6 +9,7 @@ public abstract class com/splendo/kaluga/media/BaseMediaManager : com/splendo/ka
 	protected abstract fun handleCreatePlayableMedia (Lcom/splendo/kaluga/media/MediaSource;)Lcom/splendo/kaluga/media/PlayableMedia;
 	protected fun handleError (Lcom/splendo/kaluga/media/PlaybackError;)V
 	protected fun handlePrepared (Lcom/splendo/kaluga/media/PlayableMedia;)V
+	protected fun handleRateChanged (F)V
 	protected abstract fun handleReset ()V
 	protected fun handleSeekCompleted (Z)V
 	public final fun reset ()V
@@ -107,6 +108,17 @@ public final class com/splendo/kaluga/media/MediaManager$Event$DidPrepare : com/
 	public static synthetic fun copy$default (Lcom/splendo/kaluga/media/MediaManager$Event$DidPrepare;Lcom/splendo/kaluga/media/PlayableMedia;ILjava/lang/Object;)Lcom/splendo/kaluga/media/MediaManager$Event$DidPrepare;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPlayableMedia ()Lcom/splendo/kaluga/media/PlayableMedia;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/splendo/kaluga/media/MediaManager$Event$RateDidChange : com/splendo/kaluga/media/MediaManager$Event {
+	public fun <init> (F)V
+	public final fun component1 ()F
+	public final fun copy (F)Lcom/splendo/kaluga/media/MediaManager$Event$RateDidChange;
+	public static synthetic fun copy$default (Lcom/splendo/kaluga/media/MediaManager$Event$RateDidChange;FILjava/lang/Object;)Lcom/splendo/kaluga/media/MediaManager$Event$RateDidChange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNewRate ()F
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -279,6 +291,10 @@ public final class com/splendo/kaluga/media/PlaybackError$PlaybackHasEnded : com
 
 public final class com/splendo/kaluga/media/PlaybackError$TimedOut : com/splendo/kaluga/media/PlaybackError {
 	public static final field INSTANCE Lcom/splendo/kaluga/media/PlaybackError$TimedOut;
+}
+
+public final class com/splendo/kaluga/media/PlaybackError$Uninitalized : com/splendo/kaluga/media/PlaybackError {
+	public static final field INSTANCE Lcom/splendo/kaluga/media/PlaybackError$Uninitalized;
 }
 
 public final class com/splendo/kaluga/media/PlaybackError$Unknown : com/splendo/kaluga/media/PlaybackError {

--- a/media/src/commonMain/kotlin/MediaManager.kt
+++ b/media/src/commonMain/kotlin/MediaManager.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -80,6 +81,8 @@ interface MediaManager : VolumeController, MediaSurfaceController {
          * @property error the [PlaybackError] that occurred
          */
         data class DidFailWithError(val error: PlaybackError) : Event()
+
+        data class RateDidChange(val newRate: Float) : Event()
 
         /**
          * An [Event] indicating playback completed
@@ -153,7 +156,7 @@ interface MediaManager : VolumeController, MediaSurfaceController {
  */
 abstract class BaseMediaManager(private val mediaSurfaceProvider: MediaSurfaceProvider?, coroutineContext: CoroutineContext) :
     MediaManager,
-    CoroutineScope by CoroutineScope(coroutineContext + CoroutineName("MediaManager")) {
+    CoroutineScope by CoroutineScope(coroutineContext + Job(coroutineContext.job) + CoroutineName("MediaManager")) {
 
         /**
          * Builder for creating a [BaseMediaManager]
@@ -205,6 +208,10 @@ abstract class BaseMediaManager(private val mediaSurfaceProvider: MediaSurfacePr
 
         protected open fun handleCompleted() {
             _events.trySend(MediaManager.Event.DidComplete)
+        }
+
+        protected open fun handleRateChanged(newRate: Float) {
+            _events.trySend(MediaManager.Event.RateDidChange(newRate))
         }
 
         final override suspend fun seekTo(duration: Duration): Boolean {

--- a/media/src/commonMain/kotlin/MediaManager.kt
+++ b/media/src/commonMain/kotlin/MediaManager.kt
@@ -82,6 +82,10 @@ interface MediaManager : VolumeController, MediaSurfaceController {
          */
         data class DidFailWithError(val error: PlaybackError) : Event()
 
+        /**
+         * An [Event] indicating the rate was changed
+         * @property newRate the new rate at which playback occurs
+         */
         data class RateDidChange(val newRate: Float) : Event()
 
         /**

--- a/media/src/commonMain/kotlin/MediaPlayer.kt
+++ b/media/src/commonMain/kotlin/MediaPlayer.kt
@@ -414,8 +414,11 @@ class DefaultMediaPlayer(
                     }
                 } else {
                     if (restartIfStarted) {
-                        state.seekTo(Duration.ZERO)
+                        state.seekTo(Duration.ZERO).also {
+                            println("MediaPlayer did Seek to $it")
+                        }
                     }
+                    println("MediaPlayer did Play")
                     emit(Unit)
                 }
             }

--- a/media/src/commonMain/kotlin/PlaybackState.kt
+++ b/media/src/commonMain/kotlin/PlaybackState.kt
@@ -239,6 +239,8 @@ sealed interface PlaybackState : KalugaState {
          * Transitions into a [PlayingOrCompleted] state
          */
         val completedLoop: suspend () -> PlayingOrCompleted
+
+        override fun updatePlaybackParameters(new: PlaybackParameters): suspend () -> Playing
     }
 
     /**
@@ -250,6 +252,17 @@ sealed interface PlaybackState : KalugaState {
          * Transitions back into a [Playing] state
          */
         val play: suspend () -> Playing
+
+        /**
+         * Will transition into a [Playing] state with new [PlaybackParameters]
+         * @param new the [PlaybackParameters] to update to
+         * @return a method for transitioning into a new [Playing] state
+         */
+        fun playWithUpdatedPlaybackParameters(new: PlaybackParameters) = suspend {
+            updatePlaybackParameters(new)().play()
+        }
+
+        override fun updatePlaybackParameters(new: PlaybackParameters): suspend () -> Paused
     }
 
     /**

--- a/media/src/commonMain/kotlin/PlaybackState.kt
+++ b/media/src/commonMain/kotlin/PlaybackState.kt
@@ -54,6 +54,11 @@ sealed class PlaybackError : Exception() {
     object PlaybackHasEnded : PlaybackError()
 
     /**
+     * A [PlaybackError] that indicates that playback has not been initialized.
+     */
+    object Uninitalized : PlaybackError()
+
+    /**
      * An unknown [PlaybackError].
      */
     object Unknown : PlaybackError()
@@ -355,7 +360,6 @@ internal sealed class PlaybackStateImpl {
     ) : Prepared(), PlaybackState.Playing, HandleBeforeOldStateIsRemoved<PlaybackState> {
 
         override val completedLoop: suspend () -> PlaybackState.PlayingOrCompleted = {
-            println("MediaPlayer completed loop")
             val newLoopMode = when (val loopMode = playbackParameters.loopMode) {
                 is PlaybackState.LoopMode.NotLooping -> PlaybackState.LoopMode.NotLooping
                 is PlaybackState.LoopMode.LoopingForever -> PlaybackState.LoopMode.LoopingForever

--- a/media/src/commonMain/kotlin/PlaybackState.kt
+++ b/media/src/commonMain/kotlin/PlaybackState.kt
@@ -355,6 +355,7 @@ internal sealed class PlaybackStateImpl {
     ) : Prepared(), PlaybackState.Playing, HandleBeforeOldStateIsRemoved<PlaybackState> {
 
         override val completedLoop: suspend () -> PlaybackState.PlayingOrCompleted = {
+            println("MediaPlayer completed loop")
             val newLoopMode = when (val loopMode = playbackParameters.loopMode) {
                 is PlaybackState.LoopMode.NotLooping -> PlaybackState.LoopMode.NotLooping
                 is PlaybackState.LoopMode.LoopingForever -> PlaybackState.LoopMode.LoopingForever

--- a/media/src/commonMain/kotlin/PlaybackStateRepo.kt
+++ b/media/src/commonMain/kotlin/PlaybackStateRepo.kt
@@ -64,16 +64,7 @@ open class PlaybackStateRepo(
                 when (event) {
                     is MediaManager.Event.DidPrepare -> takeAndChangeState(PlaybackState.Initialized::class) { it.prepared(event.playableMedia) }
                     is MediaManager.Event.DidFailWithError -> takeAndChangeState(PlaybackState.Active::class) { it.failWithError(event.error) }
-                    is MediaManager.Event.RateDidChange -> takeAndChangeState(PlaybackState.Started::class) { state ->
-                        when (event.newRate) {
-                            0.0f -> when (state) {
-                                is PlaybackState.Playing -> state.pause
-                                is PlaybackState.Paused -> state.remain()
-                            }
-                            state.playbackParameters.rate -> state.remain()
-                            else -> state.updatePlaybackParameters(state.playbackParameters.copy(rate = event.newRate))
-                        }
-                    }
+                    is MediaManager.Event.RateDidChange -> updateToRate(event.newRate)
                     is MediaManager.Event.DidComplete -> takeAndChangeState(PlaybackState.Playing::class) { it.completedLoop }
                     is MediaManager.Event.DidEnd -> takeAndChangeState(PlaybackState.Active::class) { it.end }
                 }
@@ -83,6 +74,21 @@ open class PlaybackStateRepo(
             takeUntilLast(false).last()
         }.invokeOnCompletion {
             mediaManager.close()
+        }
+    }
+
+    private suspend fun updateToRate(newRate: Float) = takeAndChangeState(PlaybackState.Started::class) { state ->
+        when (state) {
+            is PlaybackState.Playing -> when (newRate) {
+                0.0f -> state.pause
+                state.playbackParameters.rate -> state.remain()
+                else -> state.updatePlaybackParameters(state.playbackParameters.copy(rate = newRate))
+            }
+            is PlaybackState.Paused -> when (newRate) {
+                0.0f -> state.remain()
+                state.playbackParameters.rate -> state.play
+                else -> state.playWithUpdatedPlaybackParameters(state.playbackParameters.copy(rate = newRate))
+            }
         }
     }
 }

--- a/media/src/iosMain/kotlin/MediaSource.kt
+++ b/media/src/iosMain/kotlin/MediaSource.kt
@@ -17,6 +17,7 @@
 
 package com.splendo.kaluga.media
 
+import com.splendo.kaluga.media.MediaSource.URL.Option
 import platform.AVFoundation.AVAsset
 import platform.AVFoundation.AVAssetReferenceRestrictions
 import platform.AVFoundation.AVURLAssetAllowsCellularAccessKey
@@ -48,46 +49,87 @@ actual sealed class MediaSource {
     /**
      * A [MediaSource] that is located at a [NSURL]
      * @property url the [NSURL] at which the media is located
+     * @property options a list of [Option] used to customize the initialization of the asset
      */
-    data class URL(val url: NSURL, val options: List<Options> = emptyList()) : MediaSource() {
-        sealed class Options {
-            abstract val entry: Pair<String, Any?>
+    data class URL(val url: NSURL, val options: List<Option> = emptyList()) : MediaSource() {
 
-            data class AllowsCellularAccess(val isAllowed: Boolean) : Options() {
+        /**
+         * An option used to customize the initialization of a [URL] asset
+         */
+        sealed class Option {
+            internal abstract val entry: Pair<String, Any?>
+
+            /**
+             * An [Option] value that indicates whether the system can make network requests on behalf of the asset when connected to a cellular network.
+             * @property isAllowed if `true` the system can make network requests on behalf of the asset when connected to a cellular network
+             */
+            data class AllowsCellularAccess(val isAllowed: Boolean) : Option() {
                 override val entry: Pair<String, Any?> = AVURLAssetAllowsCellularAccessKey to isAllowed
             }
 
-            data class AllowsConstrainedNetworkAccess(val isAllowed: Boolean) : Options() {
+            /**
+             * An [Option] value that indicates whether the system allows network requests on behalf of this asset to use the constrained interface.
+             * @property isAllowed if `true` the system allows network requests on behalf of this asset to use the constrained interface.
+             */
+            data class AllowsConstrainedNetworkAccess(val isAllowed: Boolean) : Option() {
                 override val entry: Pair<String, Any?> = AVURLAssetAllowsConstrainedNetworkAccessKey to isAllowed
             }
 
-            data class AllowsExpensiveNetworkAccess(val isAllowed: Boolean) : Options() {
+            /**
+             * An [Option] value that indicates whether the system allows network requests on behalf of this asset to use the expensive interface.
+             * @property isAllowed if `true` the system allows network requests on behalf of this asset to use the expensive interface.
+             */
+            data class AllowsExpensiveNetworkAccess(val isAllowed: Boolean) : Option() {
                 override val entry: Pair<String, Any?> = AVURLAssetAllowsExpensiveNetworkAccessKey to isAllowed
             }
 
-            data class HTTPCookies(val cookies: List<NSHTTPCookie>) : Options() {
+            /**
+             * An [Option] that provides the HTTP cookies that a [URL] asset may send with HTTP requests.
+             * @property cookies a list of [NSHTTPCookie] that a [URL] asset may send with HTTP requests.
+             */
+            data class HTTPCookies(val cookies: List<NSHTTPCookie>) : Option() {
                 override val entry: Pair<String, Any?> = AVURLAssetHTTPCookiesKey to cookies
             }
 
-            data class UserAgent(val userAgent: String) : Options() {
+            /**
+             * An [Option] that specifies the user agent of requests that an asset makes.
+             * @property userAgent the user agent of requests that an asset makes.
+             */
+            data class UserAgent(val userAgent: String) : Option() {
                 override val entry: Pair<String, Any?> = AVURLAssetHTTPUserAgentKey to userAgent
             }
 
-            data class PreferPreciseDurationAndTiming(val isPreferred: Boolean) : Options() {
+            /**
+             * An [Option] value that indicates whether the asset should provide accurate duration and precise random access by time.
+             * @property isPreferred if `true` the asset should provide accurate duration and precise random access by time.
+             */
+            data class PreferPreciseDurationAndTiming(val isPreferred: Boolean) : Option() {
                 override val entry: Pair<String, Any?> = AVURLAssetPreferPreciseDurationAndTimingKey to isPreferred
             }
 
-            data class PrimarySessionIdentifier(val identifier: NSUUID) : Options() {
+            /**
+             * An [Option] that specifies a UUID to set as the session identifier for HTTP requests that the asset makes.
+             * @property identifier the [NSUUID] to set as the session identifier for HTTP requests that the asset makes.
+             */
+            data class PrimarySessionIdentifier(val identifier: NSUUID) : Option() {
                 override val entry: Pair<String, Any?> = AVURLAssetPrimarySessionIdentifierKey to identifier
             }
 
-            data class ReferenceRestrictions(val restrictions: List<AVAssetReferenceRestrictions>) : Options() {
+            /**
+             * An [Option] that represents the restrictions used by the asset when resolving references to external media data.
+             * @property restrictions the list of [AVAssetReferenceRestrictions] used by the asset when resolving references to external media data.
+             */
+            data class ReferenceRestrictions(val restrictions: List<AVAssetReferenceRestrictions>) : Option() {
                 override val entry: Pair<String, Any?> = AVURLAssetReferenceRestrictionsKey to NSNumber(
                     unsignedInteger = restrictions.fold(0UL) { acc, restriction -> acc or restriction },
                 )
             }
 
-            data class RequestAttribution(val attribution: NSURLRequestAttribution) : Options() {
+            /**
+             * A [Option] that specifies the attribution of the URLs that this asset requests.
+             * @property attribution the [NSURLRequestAttribution] of the URLs that this asset requests.
+             */
+            data class RequestAttribution(val attribution: NSURLRequestAttribution) : Option() {
                 override val entry: Pair<String, Any?> = AVURLAssetURLRequestAttributionKey to attribution
             }
         }
@@ -101,4 +143,4 @@ actual sealed class MediaSource {
  */
 actual fun mediaSourceFromUrl(
     url: String,
-): MediaSource? = NSURL.URLWithString(url)?.let { MediaSource.URL(it, options = listOf(MediaSource.URL.Options.PreferPreciseDurationAndTiming(true))) }
+): MediaSource? = NSURL.URLWithString(url)?.let { MediaSource.URL(it, options = listOf(MediaSource.URL.Option.PreferPreciseDurationAndTiming(true))) }

--- a/media/src/iosMain/kotlin/MediaSource.kt
+++ b/media/src/iosMain/kotlin/MediaSource.kt
@@ -82,13 +82,14 @@ actual sealed class MediaSource {
             }
 
             data class ReferenceRestrictions(val restrictions: List<AVAssetReferenceRestrictions>) : Options() {
-                override val entry: Pair<String, Any?> = AVURLAssetReferenceRestrictionsKey to NSNumber(unsignedInteger = restrictions.fold(0UL) { acc, restriction -> acc or restriction })
+                override val entry: Pair<String, Any?> = AVURLAssetReferenceRestrictionsKey to NSNumber(
+                    unsignedInteger = restrictions.fold(0UL) { acc, restriction -> acc or restriction },
+                )
             }
 
             data class RequestAttribution(val attribution: NSURLRequestAttribution) : Options() {
                 override val entry: Pair<String, Any?> = AVURLAssetURLRequestAttributionKey to attribution
             }
-
         }
     }
 }
@@ -98,4 +99,6 @@ actual sealed class MediaSource {
  * @param url the url String of the media source
  * @return the [MediaSource] associated with [url] or `null` if none could be created
  */
-actual fun mediaSourceFromUrl(url: String): MediaSource? = NSURL.URLWithString(url)?.let { MediaSource.URL(it) }
+actual fun mediaSourceFromUrl(
+    url: String,
+): MediaSource? = NSURL.URLWithString(url)?.let { MediaSource.URL(it, options = listOf(MediaSource.URL.Options.PreferPreciseDurationAndTiming(true))) }

--- a/media/src/iosMain/kotlin/MediaSource.kt
+++ b/media/src/iosMain/kotlin/MediaSource.kt
@@ -18,7 +18,21 @@
 package com.splendo.kaluga.media
 
 import platform.AVFoundation.AVAsset
+import platform.AVFoundation.AVAssetReferenceRestrictions
+import platform.AVFoundation.AVURLAssetAllowsCellularAccessKey
+import platform.AVFoundation.AVURLAssetAllowsConstrainedNetworkAccessKey
+import platform.AVFoundation.AVURLAssetAllowsExpensiveNetworkAccessKey
+import platform.AVFoundation.AVURLAssetHTTPCookiesKey
+import platform.AVFoundation.AVURLAssetHTTPUserAgentKey
+import platform.AVFoundation.AVURLAssetPreferPreciseDurationAndTimingKey
+import platform.AVFoundation.AVURLAssetPrimarySessionIdentifierKey
+import platform.AVFoundation.AVURLAssetReferenceRestrictionsKey
+import platform.AVFoundation.AVURLAssetURLRequestAttributionKey
+import platform.Foundation.NSHTTPCookie
+import platform.Foundation.NSNumber
 import platform.Foundation.NSURL
+import platform.Foundation.NSURLRequestAttribution
+import platform.Foundation.NSUUID
 
 /**
  * The source at which [PlayableMedia] can be found
@@ -35,7 +49,48 @@ actual sealed class MediaSource {
      * A [MediaSource] that is located at a [NSURL]
      * @property url the [NSURL] at which the media is located
      */
-    data class URL(val url: NSURL) : MediaSource()
+    data class URL(val url: NSURL, val options: List<Options> = emptyList()) : MediaSource() {
+        sealed class Options {
+            abstract val entry: Pair<String, Any?>
+
+            data class AllowsCellularAccess(val isAllowed: Boolean) : Options() {
+                override val entry: Pair<String, Any?> = AVURLAssetAllowsCellularAccessKey to isAllowed
+            }
+
+            data class AllowsConstrainedNetworkAccess(val isAllowed: Boolean) : Options() {
+                override val entry: Pair<String, Any?> = AVURLAssetAllowsConstrainedNetworkAccessKey to isAllowed
+            }
+
+            data class AllowsExpensiveNetworkAccess(val isAllowed: Boolean) : Options() {
+                override val entry: Pair<String, Any?> = AVURLAssetAllowsExpensiveNetworkAccessKey to isAllowed
+            }
+
+            data class HTTPCookies(val cookies: List<NSHTTPCookie>) : Options() {
+                override val entry: Pair<String, Any?> = AVURLAssetHTTPCookiesKey to cookies
+            }
+
+            data class UserAgent(val userAgent: String) : Options() {
+                override val entry: Pair<String, Any?> = AVURLAssetHTTPUserAgentKey to userAgent
+            }
+
+            data class PreferPreciseDurationAndTiming(val isPreferred: Boolean) : Options() {
+                override val entry: Pair<String, Any?> = AVURLAssetPreferPreciseDurationAndTimingKey to isPreferred
+            }
+
+            data class PrimarySessionIdentifier(val identifier: NSUUID) : Options() {
+                override val entry: Pair<String, Any?> = AVURLAssetPrimarySessionIdentifierKey to identifier
+            }
+
+            data class ReferenceRestrictions(val restrictions: List<AVAssetReferenceRestrictions>) : Options() {
+                override val entry: Pair<String, Any?> = AVURLAssetReferenceRestrictionsKey to NSNumber(unsignedInteger = restrictions.fold(0UL) { acc, restriction -> acc or restriction })
+            }
+
+            data class RequestAttribution(val attribution: NSURLRequestAttribution) : Options() {
+                override val entry: Pair<String, Any?> = AVURLAssetURLRequestAttributionKey to attribution
+            }
+
+        }
+    }
 }
 
 /**

--- a/test-utils-media/api/androidLib/test-utils-media.api
+++ b/test-utils-media/api/androidLib/test-utils-media.api
@@ -233,6 +233,7 @@ public final class com/splendo/kaluga/test/media/MockPlaybackState$Paused : com/
 	public fun getPlaybackParameters ()Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;
 	public fun getPlaybackState ()Lcom/splendo/kaluga/media/PlaybackState;
 	public fun hashCode ()I
+	public fun playWithUpdatedPlaybackParameters (Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;)Lkotlin/jvm/functions/Function1;
 	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun toString ()Ljava/lang/String;
 	public fun updatePlaybackParameters (Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;)Lkotlin/jvm/functions/Function1;

--- a/test-utils-media/api/jvm/test-utils-media.api
+++ b/test-utils-media/api/jvm/test-utils-media.api
@@ -233,6 +233,7 @@ public final class com/splendo/kaluga/test/media/MockPlaybackState$Paused : com/
 	public fun getPlaybackParameters ()Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;
 	public fun getPlaybackState ()Lcom/splendo/kaluga/media/PlaybackState;
 	public fun hashCode ()I
+	public fun playWithUpdatedPlaybackParameters (Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;)Lkotlin/jvm/functions/Function1;
 	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun toString ()Ljava/lang/String;
 	public fun updatePlaybackParameters (Lcom/splendo/kaluga/media/PlaybackState$PlaybackParameters;)Lkotlin/jvm/functions/Function1;


### PR DESCRIPTION
* State machine now tracks OS initiated changes to play rate
* Can be set to support background playback
* Can be set to keep playing after headphone disconnect
* awaitCompletion() now throws when reset before being completed
* Add options to AVAsset using a URL
