### PR TITLE
MockDevice support connect/disconnect

### DIFF
--- a/test-utils-bluetooth/README.md
+++ b/test-utils-bluetooth/README.md
@@ -36,7 +36,7 @@ val device = buildMockDevice(coroutineContext) {
 }
 ```
 
-Simulate connection to the device after given delay (`connectionDelay`) and check connected state afterwords:
+Simulate connection to the device after given delay (`connectionDelay`) and check connected state afterwards:
 
 ```kotlin
 device.connect()

--- a/test-utils-bluetooth/README.md
+++ b/test-utils-bluetooth/README.md
@@ -18,5 +18,34 @@ dependencies {
 ```
 
 ## Mocks
-This library contains mock classes for `Scanner`, `DeviceConnectionManager`, `AdvertisementData`, `Characteristic`, `Descriptor`, and `BluetoothMonitor`.
-In addition use `createDeviceWrapper` and `createServiceWrapper` to generate mocked Device and Service wrappers.
+This library contains mock classes for `Scanner`, `DeviceConnectionManager`, `AdvertisementData`, `Characteristic`, `Descriptor`, `BluetoothMonitor`, and `MockDevice`.
+In addition use `createDeviceWrapper`, `createServiceWrapper` to generate mocked Device and Service wrappers.
+
+### Using MockDevice
+
+Create mock using `buildMockDevice`:
+
+```kotlin
+val device = buildMockDevice(coroutineContext) {
+    identifier = identifierFromString("1234")!!
+    manufacturerId = 0xf00d
+    services {
+        add(uuidFrom("2345"))
+    }
+    connectionDelay = 100.milliseconds
+}
+```
+
+Simulate connection to the device after given delay (`connectionDelay`) and check connected state afterwords:
+
+```kotlin
+device.connect()
+device.state.firstInstance<ConnectableDeviceState.Connected>()
+```
+
+Disconnect from the device:
+
+```kotlin
+device.disconnect()
+device.state.firstInstance<ConnectableDeviceState.Disconnected>()
+```

--- a/test-utils-bluetooth/api/androidLib/test-utils-bluetooth.api
+++ b/test-utils-bluetooth/api/androidLib/test-utils-bluetooth.api
@@ -120,6 +120,34 @@ public final class com/splendo/kaluga/test/bluetooth/MockDescriptor : com/splend
 public abstract interface class com/splendo/kaluga/test/bluetooth/MockDescriptorWrapper : com/splendo/kaluga/bluetooth/DescriptorWrapper, com/splendo/kaluga/test/bluetooth/CanUpdateMockValue {
 }
 
+public final class com/splendo/kaluga/test/bluetooth/MockDeviceBuilder {
+	public fun <init> (Lkotlin/coroutines/CoroutineContext;)V
+	public final fun build ()Lcom/splendo/kaluga/test/bluetooth/device/MockDevice;
+	public final fun getConnectionDelay-UwyO8pc ()J
+	public final fun getIdentifier ()Ljava/lang/String;
+	public final fun getManufacturerData ()[B
+	public final fun getManufacturerId ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getRssi ()I
+	public final fun getSetupMocks ()Z
+	public final fun getTxPower ()I
+	public final fun isConnectable ()Z
+	public final fun services (Lkotlin/jvm/functions/Function1;)V
+	public final fun setConnectable (Z)V
+	public final fun setConnectionDelay-LRDsOJo (J)V
+	public final fun setIdentifier (Ljava/lang/String;)V
+	public final fun setManufacturerData ([B)V
+	public final fun setManufacturerId (Ljava/lang/Integer;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setRssi (I)V
+	public final fun setSetupMocks (Z)V
+	public final fun setTxPower (I)V
+}
+
+public final class com/splendo/kaluga/test/bluetooth/MockDeviceBuilderKt {
+	public static final fun buildMockDevice (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lcom/splendo/kaluga/test/bluetooth/device/MockDevice;
+}
+
 public final class com/splendo/kaluga/test/bluetooth/MockDeviceInfoBuilder {
 	public fun <init> ()V
 	public final fun build ()Lcom/splendo/kaluga/bluetooth/device/DeviceInfoImpl;

--- a/test-utils-bluetooth/api/androidLib/test-utils-bluetooth.api
+++ b/test-utils-bluetooth/api/androidLib/test-utils-bluetooth.api
@@ -264,6 +264,12 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockAdvertisementDat
 
 public final class com/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager {
 	public fun <init> ()V
+	public final fun connect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun discoverServices (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMockConnect ()Lcom/splendo/kaluga/test/base/mock/SuspendMethodMock;
+	public final fun getMockDisconnect ()Lcom/splendo/kaluga/test/base/mock/SuspendMethodMock;
+	public final fun getMockDiscoverServices ()Lcom/splendo/kaluga/test/base/mock/SuspendMethodMock;
 	public final fun getMockHandleCancelConnecting ()Lcom/splendo/kaluga/test/base/mock/MethodMock;
 	public final fun getMockHandleCancelReconnecting ()Lcom/splendo/kaluga/test/base/mock/MethodMock;
 	public final fun getMockPair ()Lcom/splendo/kaluga/test/base/mock/SuspendMethodMock;
@@ -289,8 +295,8 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockConnectableDevic
 }
 
 public final class com/splendo/kaluga/test/bluetooth/device/MockDevice : com/splendo/kaluga/bluetooth/device/Device {
-	public fun <init> (Ljava/lang/String;Lkotlinx/coroutines/flow/MutableStateFlow;Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings;Lkotlin/coroutines/CoroutineContext;Z)V
-	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/coroutines/flow/MutableStateFlow;Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings;Lkotlin/coroutines/CoroutineContext;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/coroutines/flow/MutableStateFlow;Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings;Lkotlin/coroutines/CoroutineContext;ZJLcom/splendo/kaluga/logging/Logger;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/coroutines/flow/MutableStateFlow;Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings;Lkotlin/coroutines/CoroutineContext;ZJLcom/splendo/kaluga/logging/Logger;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addAction (Lcom/splendo/kaluga/bluetooth/device/DeviceAction;)V
 	public fun advertisementDataDidUpdate (Lcom/splendo/kaluga/bluetooth/device/BaseAdvertisementData;)V
 	public final fun completeAction ()V
@@ -372,7 +378,8 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceInfo : com
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract class com/splendo/kaluga/test/bluetooth/device/MockDeviceState {
+public abstract class com/splendo/kaluga/test/bluetooth/device/MockDeviceState : com/splendo/kaluga/base/state/KalugaState {
+	public fun remain ()Lkotlin/jvm/functions/Function1;
 }
 
 public abstract class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connectable : com/splendo/kaluga/test/bluetooth/device/MockDeviceState {
@@ -393,8 +400,10 @@ public abstract class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$C
 public abstract class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connected$DiscoveredServices : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connected {
 }
 
-public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connected$Discovering : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connected, com/splendo/kaluga/bluetooth/device/ConnectableDeviceState$Connected$Discovering {
+public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connected$Discovering : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connected, com/splendo/kaluga/base/state/HandleAfterOldStateIsRemoved, com/splendo/kaluga/bluetooth/device/ConnectableDeviceState$Connected$Discovering {
 	public fun <init> (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;Ljava/lang/Integer;Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;)V
+	public synthetic fun afterOldStateIsRemoved (Lcom/splendo/kaluga/base/state/KalugaState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun afterOldStateIsRemoved (Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun component1 ()Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;
 	public final fun component2 ()Ljava/lang/Integer;
 	public final fun component3 ()Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;
@@ -409,7 +418,6 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Conn
 	public fun getReconnect ()Lkotlin/jvm/functions/Function1;
 	public fun getReconnectionSettings ()Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun toString ()Ljava/lang/String;
 	public fun updateReconnectionSettings (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;)Lkotlin/jvm/functions/Function1;
 }
@@ -437,7 +445,6 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Conn
 	public fun getReconnectionSettings ()Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;
 	public fun getServices ()Ljava/util/List;
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun toString ()Ljava/lang/String;
 	public fun updateReconnectionSettings (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;)Lkotlin/jvm/functions/Function1;
 }
@@ -460,7 +467,6 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Conn
 	public fun getServices ()Ljava/util/List;
 	public fun handleAction (Lcom/splendo/kaluga/bluetooth/device/DeviceAction;)Lkotlin/jvm/functions/Function1;
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun toString ()Ljava/lang/String;
 	public fun updateReconnectionSettings (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;)Lkotlin/jvm/functions/Function1;
 }
@@ -481,14 +487,15 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Conn
 	public fun getReconnect ()Lkotlin/jvm/functions/Function1;
 	public fun getReconnectionSettings ()Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun startDiscovering ()V
 	public fun toString ()Ljava/lang/String;
 	public fun updateReconnectionSettings (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;)Lkotlin/jvm/functions/Function1;
 }
 
-public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connecting : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connectable, com/splendo/kaluga/bluetooth/device/ConnectableDeviceState$Connecting {
+public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connecting : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connectable, com/splendo/kaluga/base/state/HandleAfterOldStateIsRemoved, com/splendo/kaluga/bluetooth/device/ConnectableDeviceState$Connecting {
 	public fun <init> (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;)V
+	public synthetic fun afterOldStateIsRemoved (Lcom/splendo/kaluga/base/state/KalugaState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun afterOldStateIsRemoved (Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun component2 ()Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;
 	public final fun copy (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;)Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connecting;
 	public static synthetic fun copy$default (Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connecting;Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;ILjava/lang/Object;)Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connecting;
@@ -499,7 +506,6 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Conn
 	public fun getMockConnectableDeviceManager ()Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;
 	public fun handleCancel ()V
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -513,13 +519,14 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disc
 	public fun getAsDeviceState ()Lcom/splendo/kaluga/bluetooth/device/ConnectableDeviceState;
 	public fun getMockConnectableDeviceManager ()Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun startConnecting (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;)V
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disconnecting : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connectable, com/splendo/kaluga/bluetooth/device/ConnectableDeviceState$Disconnecting {
+public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disconnecting : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connectable, com/splendo/kaluga/base/state/HandleAfterOldStateIsRemoved, com/splendo/kaluga/bluetooth/device/ConnectableDeviceState$Disconnecting {
 	public fun <init> (Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;)V
+	public synthetic fun afterOldStateIsRemoved (Lcom/splendo/kaluga/base/state/KalugaState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun afterOldStateIsRemoved (Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun component1 ()Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;
 	public final fun copy (Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;)Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disconnecting;
 	public static synthetic fun copy$default (Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disconnecting;Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;ILjava/lang/Object;)Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disconnecting;
@@ -527,7 +534,6 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disc
 	public fun getAsDeviceState ()Lcom/splendo/kaluga/bluetooth/device/ConnectableDeviceState;
 	public fun getMockConnectableDeviceManager ()Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/test-utils-bluetooth/api/jvm/test-utils-bluetooth.api
+++ b/test-utils-bluetooth/api/jvm/test-utils-bluetooth.api
@@ -183,6 +183,12 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockAdvertisementDat
 
 public final class com/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager {
 	public fun <init> ()V
+	public final fun connect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun disconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun discoverServices (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getMockConnect ()Lcom/splendo/kaluga/test/base/mock/SuspendMethodMock;
+	public final fun getMockDisconnect ()Lcom/splendo/kaluga/test/base/mock/SuspendMethodMock;
+	public final fun getMockDiscoverServices ()Lcom/splendo/kaluga/test/base/mock/SuspendMethodMock;
 	public final fun getMockHandleCancelConnecting ()Lcom/splendo/kaluga/test/base/mock/MethodMock;
 	public final fun getMockHandleCancelReconnecting ()Lcom/splendo/kaluga/test/base/mock/MethodMock;
 	public final fun getMockPair ()Lcom/splendo/kaluga/test/base/mock/SuspendMethodMock;
@@ -208,8 +214,8 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockConnectableDevic
 }
 
 public final class com/splendo/kaluga/test/bluetooth/device/MockDevice : com/splendo/kaluga/bluetooth/device/Device {
-	public fun <init> (Lcom/splendo/kaluga/bluetooth/UUID;Lkotlinx/coroutines/flow/MutableStateFlow;Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings;Lkotlin/coroutines/CoroutineContext;Z)V
-	public synthetic fun <init> (Lcom/splendo/kaluga/bluetooth/UUID;Lkotlinx/coroutines/flow/MutableStateFlow;Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings;Lkotlin/coroutines/CoroutineContext;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/splendo/kaluga/bluetooth/UUID;Lkotlinx/coroutines/flow/MutableStateFlow;Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings;Lkotlin/coroutines/CoroutineContext;ZJLcom/splendo/kaluga/logging/Logger;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/splendo/kaluga/bluetooth/UUID;Lkotlinx/coroutines/flow/MutableStateFlow;Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings;Lkotlin/coroutines/CoroutineContext;ZJLcom/splendo/kaluga/logging/Logger;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addAction (Lcom/splendo/kaluga/bluetooth/device/DeviceAction;)V
 	public fun advertisementDataDidUpdate (Lcom/splendo/kaluga/bluetooth/device/BaseAdvertisementData;)V
 	public final fun completeAction ()V
@@ -291,7 +297,8 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceInfo : com
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract class com/splendo/kaluga/test/bluetooth/device/MockDeviceState {
+public abstract class com/splendo/kaluga/test/bluetooth/device/MockDeviceState : com/splendo/kaluga/base/state/KalugaState {
+	public fun remain ()Lkotlin/jvm/functions/Function1;
 }
 
 public abstract class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connectable : com/splendo/kaluga/test/bluetooth/device/MockDeviceState {
@@ -312,8 +319,10 @@ public abstract class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$C
 public abstract class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connected$DiscoveredServices : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connected {
 }
 
-public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connected$Discovering : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connected, com/splendo/kaluga/bluetooth/device/ConnectableDeviceState$Connected$Discovering {
+public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connected$Discovering : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connected, com/splendo/kaluga/base/state/HandleAfterOldStateIsRemoved, com/splendo/kaluga/bluetooth/device/ConnectableDeviceState$Connected$Discovering {
 	public fun <init> (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;Ljava/lang/Integer;Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;)V
+	public synthetic fun afterOldStateIsRemoved (Lcom/splendo/kaluga/base/state/KalugaState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun afterOldStateIsRemoved (Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun component1 ()Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;
 	public final fun component2 ()Ljava/lang/Integer;
 	public final fun component3 ()Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;
@@ -328,7 +337,6 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Conn
 	public fun getReconnect ()Lkotlin/jvm/functions/Function1;
 	public fun getReconnectionSettings ()Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun toString ()Ljava/lang/String;
 	public fun updateReconnectionSettings (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;)Lkotlin/jvm/functions/Function1;
 }
@@ -356,7 +364,6 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Conn
 	public fun getReconnectionSettings ()Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;
 	public fun getServices ()Ljava/util/List;
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun toString ()Ljava/lang/String;
 	public fun updateReconnectionSettings (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;)Lkotlin/jvm/functions/Function1;
 }
@@ -379,7 +386,6 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Conn
 	public fun getServices ()Ljava/util/List;
 	public fun handleAction (Lcom/splendo/kaluga/bluetooth/device/DeviceAction;)Lkotlin/jvm/functions/Function1;
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun toString ()Ljava/lang/String;
 	public fun updateReconnectionSettings (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;)Lkotlin/jvm/functions/Function1;
 }
@@ -400,14 +406,15 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Conn
 	public fun getReconnect ()Lkotlin/jvm/functions/Function1;
 	public fun getReconnectionSettings ()Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun startDiscovering ()V
 	public fun toString ()Ljava/lang/String;
 	public fun updateReconnectionSettings (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;)Lkotlin/jvm/functions/Function1;
 }
 
-public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connecting : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connectable, com/splendo/kaluga/bluetooth/device/ConnectableDeviceState$Connecting {
+public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connecting : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connectable, com/splendo/kaluga/base/state/HandleAfterOldStateIsRemoved, com/splendo/kaluga/bluetooth/device/ConnectableDeviceState$Connecting {
 	public fun <init> (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;)V
+	public synthetic fun afterOldStateIsRemoved (Lcom/splendo/kaluga/base/state/KalugaState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun afterOldStateIsRemoved (Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun component2 ()Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;
 	public final fun copy (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;)Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connecting;
 	public static synthetic fun copy$default (Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connecting;Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;ILjava/lang/Object;)Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connecting;
@@ -418,7 +425,6 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Conn
 	public fun getMockConnectableDeviceManager ()Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;
 	public fun handleCancel ()V
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -432,13 +438,14 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disc
 	public fun getAsDeviceState ()Lcom/splendo/kaluga/bluetooth/device/ConnectableDeviceState;
 	public fun getMockConnectableDeviceManager ()Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun startConnecting (Lcom/splendo/kaluga/bluetooth/device/ConnectionSettings$ReconnectionSettings;)V
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disconnecting : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connectable, com/splendo/kaluga/bluetooth/device/ConnectableDeviceState$Disconnecting {
+public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disconnecting : com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Connectable, com/splendo/kaluga/base/state/HandleAfterOldStateIsRemoved, com/splendo/kaluga/bluetooth/device/ConnectableDeviceState$Disconnecting {
 	public fun <init> (Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;)V
+	public synthetic fun afterOldStateIsRemoved (Lcom/splendo/kaluga/base/state/KalugaState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun afterOldStateIsRemoved (Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun component1 ()Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;
 	public final fun copy (Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;)Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disconnecting;
 	public static synthetic fun copy$default (Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disconnecting;Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;ILjava/lang/Object;)Lcom/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disconnecting;
@@ -446,7 +453,6 @@ public final class com/splendo/kaluga/test/bluetooth/device/MockDeviceState$Disc
 	public fun getAsDeviceState ()Lcom/splendo/kaluga/bluetooth/device/ConnectableDeviceState;
 	public fun getMockConnectableDeviceManager ()Lcom/splendo/kaluga/test/bluetooth/device/MockConnectableDeviceManager;
 	public fun hashCode ()I
-	public fun remain ()Lkotlin/jvm/functions/Function1;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/test-utils-bluetooth/api/jvm/test-utils-bluetooth.api
+++ b/test-utils-bluetooth/api/jvm/test-utils-bluetooth.api
@@ -63,6 +63,34 @@ public final class com/splendo/kaluga/test/bluetooth/MockDescriptor : com/splend
 public abstract interface class com/splendo/kaluga/test/bluetooth/MockDescriptorWrapper : com/splendo/kaluga/bluetooth/DescriptorWrapper, com/splendo/kaluga/test/bluetooth/CanUpdateMockValue {
 }
 
+public final class com/splendo/kaluga/test/bluetooth/MockDeviceBuilder {
+	public fun <init> (Lkotlin/coroutines/CoroutineContext;)V
+	public final fun build ()Lcom/splendo/kaluga/test/bluetooth/device/MockDevice;
+	public final fun getConnectionDelay-UwyO8pc ()J
+	public final fun getIdentifier ()Lcom/splendo/kaluga/bluetooth/UUID;
+	public final fun getManufacturerData ()[B
+	public final fun getManufacturerId ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getRssi ()I
+	public final fun getSetupMocks ()Z
+	public final fun getTxPower ()I
+	public final fun isConnectable ()Z
+	public final fun services (Lkotlin/jvm/functions/Function1;)V
+	public final fun setConnectable (Z)V
+	public final fun setConnectionDelay-LRDsOJo (J)V
+	public final fun setIdentifier (Lcom/splendo/kaluga/bluetooth/UUID;)V
+	public final fun setManufacturerData ([B)V
+	public final fun setManufacturerId (Ljava/lang/Integer;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setRssi (I)V
+	public final fun setSetupMocks (Z)V
+	public final fun setTxPower (I)V
+}
+
+public final class com/splendo/kaluga/test/bluetooth/MockDeviceBuilderKt {
+	public static final fun buildMockDevice (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lcom/splendo/kaluga/test/bluetooth/device/MockDevice;
+}
+
 public final class com/splendo/kaluga/test/bluetooth/MockDeviceInfoBuilder {
 	public fun <init> ()V
 	public final fun build ()Lcom/splendo/kaluga/bluetooth/device/DeviceInfoImpl;

--- a/test-utils-bluetooth/src/commonMain/kotlin/MockDeviceBuilder.kt
+++ b/test-utils-bluetooth/src/commonMain/kotlin/MockDeviceBuilder.kt
@@ -1,0 +1,92 @@
+/*
+ Copyright 2023 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.test.bluetooth
+
+import com.splendo.kaluga.bluetooth.RSSI
+import com.splendo.kaluga.bluetooth.TxPower
+import com.splendo.kaluga.bluetooth.UUID
+import com.splendo.kaluga.bluetooth.device.Identifier
+import com.splendo.kaluga.test.bluetooth.device.MockAdvertisementData
+import com.splendo.kaluga.test.bluetooth.device.MockDevice
+import com.splendo.kaluga.test.bluetooth.device.MockDeviceInfo
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration.Companion.milliseconds
+
+class MockDeviceBuilder(
+    private val context: CoroutineContext,
+) {
+
+    /** MockDevice's identifier */
+    var identifier: Identifier = randomIdentifier()
+
+    /** MockDevice's name */
+    var name: String? = null
+
+    /** RSSI value */
+    var rssi: RSSI = Int.MIN_VALUE
+
+    /** Is connectable flag in advertisement data */
+    var isConnectable = true
+
+    /** Manufacturer id in advertisement data */
+    var manufacturerId: Int? = null
+
+    /** Manufacturer data in advertisement data */
+    var manufacturerData: ByteArray? = null
+
+    /** Tx power level in advertisement data */
+    var txPower: TxPower = Int.MIN_VALUE
+
+    /** Setup mocks */
+    var setupMocks = true
+
+    private val _serviceUUIDs = ArrayList<UUID>()
+    private val serviceUUIDs get() = _serviceUUIDs.toList()
+
+    /** Delay before connection and disconnection from the MockDevice */
+    var connectionDelay = 500.milliseconds
+
+    /** Add services advertised by the MockDevice */
+    fun services(builder: ServiceUUIDsList.() -> Unit) = builder(_serviceUUIDs)
+
+    fun build(): MockDevice = MockDevice(
+        identifier = identifier,
+        info = MutableStateFlow(
+            MockDeviceInfo(
+                identifier = identifier,
+                name = name,
+                advertisementData = MockAdvertisementData(
+                    name = name,
+                    manufacturerId = manufacturerId,
+                    manufacturerData = manufacturerData,
+                    serviceUUIDs = serviceUUIDs,
+                    txPowerLevel = txPower,
+                    isConnectable = isConnectable,
+                ),
+                rssi = rssi,
+            ),
+        ),
+        coroutineContext = context,
+        connectionDelay = connectionDelay,
+        setupMocks = setupMocks,
+    )
+}
+
+/** Build MockDevice, see [MockDeviceBuilder] */
+fun buildMockDevice(context: CoroutineContext, builder: MockDeviceBuilder.() -> Unit) = MockDeviceBuilder(context).apply(builder).build()

--- a/test-utils-bluetooth/src/commonMain/kotlin/device/MockConnectableDeviceStateRepo.kt
+++ b/test-utils-bluetooth/src/commonMain/kotlin/device/MockConnectableDeviceStateRepo.kt
@@ -49,6 +49,15 @@ class MockConnectableDeviceManager {
     val mockUnpair = this::unpair.mock()
     suspend fun unpair(): Unit = mockUnpair.call()
 
+    val mockConnect = this::connect.mock()
+    suspend fun connect(): Unit = mockConnect.call()
+
+    val mockDisconnect = this::disconnect.mock()
+    suspend fun disconnect(): Unit = mockDisconnect.call()
+
+    val mockDiscoverServices = this::discoverServices.mock()
+    suspend fun discoverServices(): Unit = mockDiscoverServices.call()
+
     val mockStartDiscovering = this::startDiscovering.mock()
     fun startDiscovering(): Unit = mockStartDiscovering.call()
 

--- a/test-utils-bluetooth/src/commonMain/kotlin/device/MockDeviceState.kt
+++ b/test-utils-bluetooth/src/commonMain/kotlin/device/MockDeviceState.kt
@@ -180,7 +180,7 @@ sealed class MockDeviceState : KalugaState {
     }
 
     data class Disconnecting(
-        override val mockConnectableDeviceManager: MockConnectableDeviceManager
+        override val mockConnectableDeviceManager: MockConnectableDeviceManager,
     ) : Connectable(), ConnectableDeviceState.Disconnecting, HandleAfterOldStateIsRemoved<MockDeviceState> {
         override val asDeviceState: ConnectableDeviceState = this
 

--- a/test-utils-bluetooth/src/commonMain/kotlin/device/MockDeviceState.kt
+++ b/test-utils-bluetooth/src/commonMain/kotlin/device/MockDeviceState.kt
@@ -17,6 +17,8 @@
 
 package com.splendo.kaluga.test.bluetooth.device
 
+import com.splendo.kaluga.base.state.HandleAfterOldStateIsRemoved
+import com.splendo.kaluga.base.state.KalugaState
 import com.splendo.kaluga.bluetooth.MTU
 import com.splendo.kaluga.bluetooth.Service
 import com.splendo.kaluga.bluetooth.device.ConnectableDeviceState
@@ -24,7 +26,7 @@ import com.splendo.kaluga.bluetooth.device.ConnectionSettings
 import com.splendo.kaluga.bluetooth.device.DeviceAction
 import com.splendo.kaluga.bluetooth.device.NotConnectableDeviceState
 
-sealed class MockDeviceState {
+sealed class MockDeviceState : KalugaState {
     data object NotConnectable : MockDeviceState(), NotConnectableDeviceState
     sealed class Connectable : MockDeviceState() {
 
@@ -73,7 +75,7 @@ sealed class MockDeviceState {
             override val reconnectionSettings: ConnectionSettings.ReconnectionSettings,
             override val mtu: MTU?,
             override val mockConnectableDeviceManager: MockConnectableDeviceManager,
-        ) : Connected(), ConnectableDeviceState.Connected.Discovering {
+        ) : Connected(), ConnectableDeviceState.Connected.Discovering, HandleAfterOldStateIsRemoved<MockDeviceState> {
             override fun didDiscoverServices(services: List<Service>): suspend () -> ConnectableDeviceState.Connected.Idle = {
                 Idle(reconnectionSettings, mtu, services, mockConnectableDeviceManager)
             }
@@ -86,6 +88,10 @@ sealed class MockDeviceState {
             override val reconnect: suspend () -> ConnectableDeviceState.Connecting = { Connecting(reconnectionSettings, mockConnectableDeviceManager) }
 
             override val asDeviceState: ConnectableDeviceState = this
+
+            override suspend fun afterOldStateIsRemoved(oldState: MockDeviceState) {
+                mockConnectableDeviceManager.discoverServices()
+            }
         }
 
         sealed class DiscoveredServices : Connected()
@@ -144,7 +150,7 @@ sealed class MockDeviceState {
     data class Connecting(
         private val reconnectionSettings: ConnectionSettings.ReconnectionSettings,
         override val mockConnectableDeviceManager: MockConnectableDeviceManager,
-    ) : Connectable(), ConnectableDeviceState.Connecting {
+    ) : Connectable(), ConnectableDeviceState.Connecting, HandleAfterOldStateIsRemoved<MockDeviceState> {
 
         override val cancelConnection: suspend () -> Disconnecting = { Disconnecting(mockConnectableDeviceManager) }
 
@@ -153,6 +159,13 @@ sealed class MockDeviceState {
         override fun handleCancel() = mockConnectableDeviceManager.handleCancelConnecting()
 
         override val asDeviceState: ConnectableDeviceState = this
+
+        override suspend fun afterOldStateIsRemoved(oldState: MockDeviceState) {
+            when (oldState) {
+                is Disconnected -> mockConnectableDeviceManager.connect()
+                else -> Unit
+            }
+        }
     }
 
     data class Disconnected(override val mockConnectableDeviceManager: MockConnectableDeviceManager) : Connectable(), ConnectableDeviceState.Disconnected {
@@ -166,7 +179,16 @@ sealed class MockDeviceState {
         override val asDeviceState: ConnectableDeviceState = this
     }
 
-    data class Disconnecting(override val mockConnectableDeviceManager: MockConnectableDeviceManager) : Connectable(), ConnectableDeviceState.Disconnecting {
+    data class Disconnecting(
+        override val mockConnectableDeviceManager: MockConnectableDeviceManager
+    ) : Connectable(), ConnectableDeviceState.Disconnecting, HandleAfterOldStateIsRemoved<MockDeviceState> {
         override val asDeviceState: ConnectableDeviceState = this
+
+        override suspend fun afterOldStateIsRemoved(oldState: MockDeviceState) {
+            when (oldState) {
+                is Connecting, is Connected -> mockConnectableDeviceManager.disconnect()
+                else -> Unit
+            }
+        }
     }
 }

--- a/test-utils-bluetooth/src/commonTest/kotlin/MockDeviceTest.kt
+++ b/test-utils-bluetooth/src/commonTest/kotlin/MockDeviceTest.kt
@@ -1,0 +1,50 @@
+/*
+ Copyright 2023 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.test.bluetooth
+
+import com.splendo.kaluga.base.runBlocking
+import com.splendo.kaluga.base.utils.firstInstance
+import com.splendo.kaluga.bluetooth.device.ConnectableDeviceState
+import com.splendo.kaluga.bluetooth.device.identifierFromString
+import com.splendo.kaluga.bluetooth.uuidFrom
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.time.Duration.Companion.milliseconds
+
+class MockDeviceTest {
+
+    @Test
+    fun mock_device_connect_disconnect(): Unit = runBlocking {
+        val device = buildMockDevice(coroutineContext) {
+            identifier = identifierFromString("1234")!!
+            services {
+                add(uuidFrom("2345"))
+            }
+            connectionDelay = 100.milliseconds
+        }
+        withTimeout(500.milliseconds) {
+            device.connect()
+            assertNotNull(device.state.firstInstance<ConnectableDeviceState.Connected>())
+        }
+        withTimeout(500.milliseconds) {
+            device.disconnect()
+            assertNotNull(device.state.firstInstance<ConnectableDeviceState.Disconnected>())
+        }
+    }
+}


### PR DESCRIPTION
<!-- fill in the issue number related to this pull request below -->

Resolves #750

Attempt to have MockDevice to be connectable and disconnectable

Current _simple_ implementation of mock device a bit confusing.
After creating object and naive calling connect() it does nothing  (even no log message that it is not supported or implemented).

This PR just keeps mock simple as it was but provides connect disconnect calls to behave similar to real world device.
