### PR TITLE
More dependencies were updated

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/splendo/kaluga-swiftui.git
 [submodule "gradle-test-recorder"]
 	path = gradle-test-recorder
-	url =  https://github.com/thoutbeckers/gradle-test-recorder.git
+	url =  https://github.com/splendo/gradle-test-recorder.git

--- a/example/gradle.properties
+++ b/example/gradle.properties
@@ -20,6 +20,6 @@ kotlin.mpp.import.enableKgpDependencyResolution=true
 # Kaluga
 kaluga.androidGradlePluginVersion=8.2.0
 kaluga.kotlinVersion=1.9.23
-kaluga.googleServicesGradlePluginVersion=4.4.0
-kaluga.kotlinterGradlePluginVersion=4.1.0
+kaluga.googleServicesGradlePluginVersion=4.4.1
+kaluga.kotlinterGradlePluginVersion=4.3.0
 kaluga.atomicFuGradlePluginVersion=0.22.0

--- a/example/gradle/wrapper/gradle-wrapper.properties
+++ b/example/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Nov 04 13:12:48 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,8 @@ kotlin.mpp.import.enableKgpDependencyResolution=true
 # Kaluga
 kaluga.androidGradlePluginVersion=8.2.0
 kaluga.kotlinVersion=1.9.23
-kaluga.googleServicesGradlePluginVersion=4.4.0
-kaluga.kotlinterGradlePluginVersion=4.1.0
+kaluga.googleServicesGradlePluginVersion=4.4.1
+kaluga.kotlinterGradlePluginVersion=4.3.0
 kaluga.atomicFuGradlePluginVersion=0.22.0
 
 
@@ -29,5 +29,5 @@ kaluga.atomicFuGradlePluginVersion=0.22.0
 #
 # below is not used by example and does not need to be kept in sync #
 
-kaluga.binaryCompatibilityValidatorVersion=0.13.2
-kaluga.dokkaVersion=1.9.10
+kaluga.binaryCompatibilityValidatorVersion=0.14.0
+kaluga.dokkaVersion=1.9.20


### PR DESCRIPTION
## Linked issues
[#770](https://github.com/splendo/kaluga/issues/770)

## Changes
- Dependencies were updated to
```
googleServicesGradlePluginVersion=4.4.1
kotlinterGradlePluginVersion=4.3.0
binaryCompatibilityValidatorVersion=0.14.0
dokkaVersion=1.9.20
gradle=8.6
```
- Use submodule `https://github.com/splendo/gradle-test-recorder` instead `https://github.com/thoutbeckers/gradle-test-recorder`