### PR TITLE
Make Publish Action also Publish to MVN Local

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,7 +40,11 @@ jobs:
         with:
           path: ~/.konan/*
           key: konan
-
+      # We're seeing some issues with publishing to Sonatype due to split up repos. By publishing to MavenLocal first we might circumvent this
+      - name: "Publish MavenLocal"
+        env:
+          MAVEN_CENTRAL_RELEASE: ${{ github.ref_name == 'master' }}
+        run: ./gradlew publishToMavenLocal --stacktrace
       - name: "Publish SNAPSHOT"
         if: ${{ github.ref_name != 'master' }}
         run: ./gradlew publishAllPublicationsToSnapshotsRepository --stacktrace


### PR DESCRIPTION
The Sonatype repository sometimes causes duplications. By publishing to MVN Local first, we create a cache that can be used for uploading. This ensures building completes before uploading
