### PR TITLE
slightly improve Kaluga Date handling in JS

### DIFF
--- a/base/src/commonTest/kotlin/utils/DateTest.kt
+++ b/base/src/commonTest/kotlin/utils/DateTest.kt
@@ -160,4 +160,19 @@ class DateTest {
         assertEquals(0, startOfDayAfterDLS.hour)
         assertEquals(29, startOfDayAfterDLS.day)
     }
+
+    @Test
+    fun testCopy() {
+        val now = DefaultKalugaDate.now(locale = KalugaLocale.enUsPosix)
+        assertEquals(now, now.copy())
+    }
+
+    @Test
+    fun testCompareTo() {
+        val offset = 1616828400000.milliseconds
+        val timestamp = DefaultKalugaDate.epoch(offset, locale = KalugaLocale.enUsPosix)
+        assertEquals(0, timestamp.compareTo(DefaultKalugaDate.epoch(offset, locale = KalugaLocale.enUsPosix)))
+        assertTrue { timestamp < DefaultKalugaDate.epoch(offset + 5.seconds, locale = KalugaLocale.enUsPosix) }
+        assertTrue { DefaultKalugaDate.epoch(offset - 5.seconds, locale = KalugaLocale.enUsPosix) < timestamp }
+    }
 }

--- a/base/src/jsMain/kotlin/utils/KalugaDate.kt
+++ b/base/src/jsMain/kotlin/utils/KalugaDate.kt
@@ -100,7 +100,7 @@ actual class DefaultKalugaDate internal constructor(actual override val date: Ka
         get() = date.getTime().milliseconds
         set(_) { }
 
-    actual override fun copy(): KalugaDate = DefaultKalugaDate(kotlin.js.Date(date.getMilliseconds()))
+    actual override fun copy(): KalugaDate = DefaultKalugaDate(kotlin.js.Date(date.getTime().toLong()))
 
     actual override fun equals(other: Any?): Boolean {
         return (other as? KalugaDate)?.let {
@@ -108,13 +108,7 @@ actual class DefaultKalugaDate internal constructor(actual override val date: Ka
         } ?: false
     }
 
-    actual override fun compareTo(other: KalugaDate): Int {
-        return when {
-            date.getMilliseconds() < other.millisecond -> -1
-            date.getMilliseconds() == other.millisecond -> 0
-            else -> 1
-        }
-    }
+    actual override fun compareTo(other: KalugaDate): Int = date.getTime().compareTo(other.date.getTime())
 
     actual override fun hashCode(): Int {
         return date.hashCode()

--- a/base/src/jsMain/kotlin/utils/KalugaTimeZone.kt
+++ b/base/src/jsMain/kotlin/utils/KalugaTimeZone.kt
@@ -54,4 +54,5 @@ actual class KalugaTimeZone internal constructor() : BaseTimeZone() {
     actual override fun offsetFromGMTAtDate(date: KalugaDate): Duration = 0.milliseconds
     actual override fun usesDaylightSavingsTime(date: KalugaDate): Boolean = false
     actual override fun copy(): KalugaTimeZone = KalugaTimeZone()
+    override fun equals(other: Any?): Boolean = other is KalugaTimeZone && identifier == other.identifier
 }


### PR DESCRIPTION
<!-- fill in the issue number related to this pull request below -->

#767 

JS implementation of a date and time zone is still incomplete, but at least copying and comparison was improved