### PR TITLE
Fixes mockfont crashing when called in certain circumstances on ios

### DIFF
--- a/test-utils-resources/src/iosMain/kotlin/MockResources.kt
+++ b/test-utils-resources/src/iosMain/kotlin/MockResources.kt
@@ -20,8 +20,9 @@ package com.splendo.kaluga.test.resources
 import com.splendo.kaluga.resources.KalugaColor
 import com.splendo.kaluga.resources.KalugaFont
 import com.splendo.kaluga.resources.KalugaImage
+import com.splendo.kaluga.resources.defaultFont
 import platform.UIKit.UIColor
 
 actual fun mockColor(): KalugaColor = KalugaColor.RGBColor(UIColor.blackColor())
 actual fun mockImage(): KalugaImage = KalugaImage()
-actual fun mockFont(): KalugaFont = KalugaFont()
+actual fun mockFont(): KalugaFont = defaultFont


### PR DESCRIPTION
<!-- fill in the issue number related to this pull request below -->

#
