### PR TITLE
Add calculations for converting Pressure/Volumetric Flow to Power

### DIFF
--- a/example/shared/src/commonMain/kotlin/com/splendo/kaluga/example/shared/model/scientific/converters/PowerConverters.kt
+++ b/example/shared/src/commonMain/kotlin/com/splendo/kaluga/example/shared/model/scientific/converters/PowerConverters.kt
@@ -108,9 +108,6 @@ val PhysicalQuantity.Power.converters get() = listOf<QuantityConverter<PhysicalQ
         PhysicalQuantity.Speed,
     ) { (leftValue, leftUnit), (rightValue, rightUnit) ->
         when {
-            leftUnit is MetricAndImperialCombinedPower && rightUnit is MetricSpeed -> {
-                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
-            }
             leftUnit is MetricCombinedPower && rightUnit is MetricSpeed -> {
                 DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
             }
@@ -127,6 +124,39 @@ val PhysicalQuantity.Power.converters get() = listOf<QuantityConverter<PhysicalQ
                 DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
             }
             leftUnit is Power && rightUnit is Speed -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            else -> throw RuntimeException("Unexpected units: $leftUnit, $rightUnit")
+        }
+    },
+    QuantityConverterWithOperator(
+        "Pressure from Volumetric Flow",
+        QuantityConverter.WithOperator.Type.Division,
+        PhysicalQuantity.VolumetricFlow,
+    ) { (leftValue, leftUnit), (rightValue, rightUnit) ->
+        when {
+            leftUnit is MetricCombinedPower && rightUnit is MetricVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialCombinedPower && rightUnit is ImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialCombinedPower && rightUnit is UKImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialCombinedPower && rightUnit is USCustomaryVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPower && rightUnit is ImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPower && rightUnit is UKImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPower && rightUnit is USCustomaryVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is Power && rightUnit is VolumetricFlow -> {
                 DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
             }
             else -> throw RuntimeException("Unexpected units: $leftUnit, $rightUnit")
@@ -220,6 +250,78 @@ val PhysicalQuantity.Power.converters get() = listOf<QuantityConverter<PhysicalQ
                 DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
             }
             leftUnit is Power && rightUnit is ElectricCurrent -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            else -> throw RuntimeException("Unexpected units: $leftUnit, $rightUnit")
+        }
+    },
+    QuantityConverterWithOperator(
+        "Volumetric Flow from Pressure",
+        QuantityConverter.WithOperator.Type.Division,
+        PhysicalQuantity.Pressure,
+    ) { (leftValue, leftUnit), (rightValue, rightUnit) ->
+        when {
+            leftUnit is MetricCombinedPower && rightUnit is Barye -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is MetricCombinedPower && rightUnit is BaryeMultiple -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialCombinedPower && rightUnit is PoundSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialCombinedPower && rightUnit is OunceSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialCombinedPower && rightUnit is KiloPoundSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialCombinedPower && rightUnit is KipSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialCombinedPower && rightUnit is USTonSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialCombinedPower && rightUnit is ImperialTonSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialCombinedPower && rightUnit is ImperialPressure -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialCombinedPower && rightUnit is UKImperialPressure -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialCombinedPower && rightUnit is USCustomaryPressure -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPower && rightUnit is PoundSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPower && rightUnit is OunceSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPower && rightUnit is KiloPoundSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPower && rightUnit is KipSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPower && rightUnit is USTonSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPower && rightUnit is ImperialTonSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPower && rightUnit is ImperialPressure -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPower && rightUnit is UKImperialPressure -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPower && rightUnit is USCustomaryPressure -> {
+                DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is Power && rightUnit is Pressure -> {
                 DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
             }
             else -> throw RuntimeException("Unexpected units: $leftUnit, $rightUnit")

--- a/example/shared/src/commonMain/kotlin/com/splendo/kaluga/example/shared/model/scientific/converters/PressureConverters.kt
+++ b/example/shared/src/commonMain/kotlin/com/splendo/kaluga/example/shared/model/scientific/converters/PressureConverters.kt
@@ -155,4 +155,79 @@ val PhysicalQuantity.Pressure.converters get() = listOf<QuantityConverter<Physic
             else -> throw RuntimeException("Unexpected units: $leftUnit, $rightUnit")
         }
     },
+    QuantityConverterWithOperator(
+        "Power from Volumetric Flow",
+        QuantityConverter.WithOperator.Type.Multiplication,
+        PhysicalQuantity.VolumetricFlow,
+    ) { (leftValue, leftUnit), (rightValue, rightUnit) ->
+        when {
+            leftUnit is Barye && rightUnit is MetricVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is BaryeMultiple && rightUnit is MetricVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is PoundSquareInch && rightUnit is ImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is PoundSquareInch && rightUnit is UKImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is PoundSquareInch && rightUnit is USCustomaryVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is OunceSquareInch && rightUnit is ImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is OunceSquareInch && rightUnit is UKImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is OunceSquareInch && rightUnit is USCustomaryVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is KiloPoundSquareInch && rightUnit is ImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is KiloPoundSquareInch && rightUnit is UKImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is KiloPoundSquareInch && rightUnit is USCustomaryVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is KipSquareInch && rightUnit is USCustomaryVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is USTonSquareInch && rightUnit is USCustomaryVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialTonSquareInch && rightUnit is UKImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPressure && rightUnit is ImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPressure && rightUnit is UKImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialPressure && rightUnit is USCustomaryVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is UKImperialPressure && rightUnit is ImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is UKImperialPressure && rightUnit is UKImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is USCustomaryPressure && rightUnit is ImperialVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is USCustomaryPressure && rightUnit is USCustomaryVolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is Pressure && rightUnit is VolumetricFlow -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            else -> throw RuntimeException("Unexpected units: $leftUnit, $rightUnit")
+        }
+    },
 )

--- a/example/shared/src/commonMain/kotlin/com/splendo/kaluga/example/shared/model/scientific/converters/VolumetricFlowConverters.kt
+++ b/example/shared/src/commonMain/kotlin/com/splendo/kaluga/example/shared/model/scientific/converters/VolumetricFlowConverters.kt
@@ -19,6 +19,7 @@ package com.splendo.kaluga.example.shared.model.scientific.converters
 
 import com.splendo.kaluga.scientific.DefaultScientificValue
 import com.splendo.kaluga.scientific.PhysicalQuantity
+import com.splendo.kaluga.scientific.converter.pressure.times
 import com.splendo.kaluga.scientific.converter.volumetricFlow.div
 import com.splendo.kaluga.scientific.converter.volumetricFlow.times
 import com.splendo.kaluga.scientific.unit.*
@@ -56,6 +57,81 @@ val PhysicalQuantity.VolumetricFlow.converters get() = listOf<QuantityConverter<
             }
             leftUnit is VolumetricFlow && rightUnit is VolumetricFlux -> {
                 DefaultScientificValue(leftValue, leftUnit) / DefaultScientificValue(rightValue, rightUnit)
+            }
+            else -> throw RuntimeException("Unexpected units: $leftUnit, $rightUnit")
+        }
+    },
+    QuantityConverterWithOperator(
+        "Power from Pressure",
+        QuantityConverter.WithOperator.Type.Multiplication,
+        PhysicalQuantity.Pressure,
+    ) { (leftValue, leftUnit), (rightValue, rightUnit) ->
+        when {
+            leftUnit is MetricVolumetricFlow && rightUnit is Barye -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is MetricVolumetricFlow && rightUnit is BaryeMultiple -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialVolumetricFlow && rightUnit is PoundSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is UKImperialVolumetricFlow && rightUnit is PoundSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is USCustomaryVolumetricFlow && rightUnit is PoundSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialVolumetricFlow && rightUnit is OunceSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is UKImperialVolumetricFlow && rightUnit is OunceSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is USCustomaryVolumetricFlow && rightUnit is OunceSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialVolumetricFlow && rightUnit is KiloPoundSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is UKImperialVolumetricFlow && rightUnit is KiloPoundSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is USCustomaryVolumetricFlow && rightUnit is KiloPoundSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is USCustomaryVolumetricFlow && rightUnit is KipSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is USCustomaryVolumetricFlow && rightUnit is USTonSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is UKImperialVolumetricFlow && rightUnit is ImperialTonSquareInch -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialVolumetricFlow && rightUnit is ImperialPressure -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is UKImperialVolumetricFlow && rightUnit is ImperialPressure -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is USCustomaryVolumetricFlow && rightUnit is ImperialPressure -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialVolumetricFlow && rightUnit is UKImperialPressure -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is UKImperialVolumetricFlow && rightUnit is UKImperialPressure -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is ImperialVolumetricFlow && rightUnit is USCustomaryPressure -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is USCustomaryVolumetricFlow && rightUnit is USCustomaryPressure -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
+            }
+            leftUnit is VolumetricFlow && rightUnit is Pressure -> {
+                DefaultScientificValue(leftValue, leftUnit) * DefaultScientificValue(rightValue, rightUnit)
             }
             else -> throw RuntimeException("Unexpected units: $leftUnit, $rightUnit")
         }

--- a/scientific/api/android/scientific.api
+++ b/scientific/api/android/scientific.api
@@ -3356,13 +3356,18 @@ public final class com/splendo/kaluga/scientific/converter/momentum/ConvertToWei
 }
 
 public final class com/splendo/kaluga/scientific/converter/power/ConvertFromEnergyAndTimeKt {
-	public static final fun powerFromEnergyAndTime (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
-	public static final fun powerFromEnergyAndTimeDefault (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun powerFromPressureAndVolumetricFlow (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
+	public static final fun powerFromPressureAndVolumetricFlowDefault (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
 public final class com/splendo/kaluga/scientific/converter/power/ConvertFromForceAndSpeedKt {
 	public static final fun powerFromForceAndSpeed (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
 	public static final fun powerFromForceAndSpeedDefault (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
+public final class com/splendo/kaluga/scientific/converter/power/ConvertFromPressureAndVolumetricFlowKt {
+	public static final fun powerFromEnergyAndTime (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
+	public static final fun powerFromEnergyAndTimeDefault (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
 public final class com/splendo/kaluga/scientific/converter/power/ConvertFromTemperatureAndThermalResistanceKt {
@@ -3409,6 +3414,17 @@ public final class com/splendo/kaluga/scientific/converter/power/ConvertToForceK
 	public static final fun powerDivSpeed (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
+public final class com/splendo/kaluga/scientific/converter/power/ConvertToPressureKt {
+	public static final fun imperialCombinedPowerDivImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun metricCombinedPowerDivMetricVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun powerDivVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
 public final class com/splendo/kaluga/scientific/converter/power/ConvertToSpeedKt {
 	public static final fun imperialCombinedPowerDivImperialForce (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 	public static final fun imperialPowerDivImperialForce (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
@@ -3440,6 +3456,30 @@ public final class com/splendo/kaluga/scientific/converter/power/ConvertToVoltag
 	public static final fun powerDivCurrent (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
+public final class com/splendo/kaluga/scientific/converter/power/ConvertToVolumetricFlowKt {
+	public static final fun imperialCombinedPowerDivImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivImperialTonSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivKiloPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivKipSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivOunceSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivUKImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivUsCustomaryPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivUsTonSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivImperialTonSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivKiloPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivKipSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivOunceSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivUKImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivUsCustomaryPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivUsTonSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun metricCombinedPowerDivBarye (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun metricCombinedPowerDivBaryeMultiple (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun powerDivPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
 public final class com/splendo/kaluga/scientific/converter/pressure/ConvertFromDynamicViscosityAndTimeKt {
 	public static final fun pressureFromDynamicViscosityAndTime (Lcom/splendo/kaluga/scientific/unit/Pressure;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
 	public static final fun pressureFromDynamicViscosityAndTimeDefault (Lcom/splendo/kaluga/scientific/unit/Pressure;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
@@ -3453,6 +3493,11 @@ public final class com/splendo/kaluga/scientific/converter/pressure/ConvertFromE
 public final class com/splendo/kaluga/scientific/converter/pressure/ConvertFromForceAndAreaKt {
 	public static final fun pressureFromForceAndArea (Lcom/splendo/kaluga/scientific/unit/Pressure;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
 	public static final fun pressureFromForceAndAreaDefault (Lcom/splendo/kaluga/scientific/unit/Pressure;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
+public final class com/splendo/kaluga/scientific/converter/pressure/ConvertFromPowerAndVolumetricFlowKt {
+	public static final fun pressureFromPowerAndVolumetricFlow (Lcom/splendo/kaluga/scientific/unit/Pressure;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
+	public static final fun pressureFromPowerAndVolumetricFlowDefault (Lcom/splendo/kaluga/scientific/unit/Pressure;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
 public final class com/splendo/kaluga/scientific/converter/pressure/ConvertToDynamicViscosityKt {
@@ -3497,6 +3542,31 @@ public final class com/splendo/kaluga/scientific/converter/pressure/ConvertToFor
 	public static final fun usCustomaryPressureTimesImperialArea (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 	public static final fun usTonSquareFeetTimesImperialArea (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 	public static final fun usTonSquareInchTimesImperialArea (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
+public final class com/splendo/kaluga/scientific/converter/pressure/ConvertToPowerKt {
+	public static final fun baryeMultipleTimesMetricVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun baryeTimesMetricVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPressureTimesImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPressureTimesUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPressureTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialTonSquareInchTimesUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun kilopoundSquareInchTimesImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun kilopoundSquareInchTimesUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun kilopoundSquareInchTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun kipSquareInchTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ounceSquareInchTimesImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ounceSquareInchTimesUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ounceSquareInchTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun poundSquareInchTimesImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun poundSquareInchTimesUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun poundSquareInchTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun pressureTimesVolume (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ukImperialPressureTimesImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ukImperialPressureTimesUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usCustomaryPressureTimesImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usCustomaryPressureTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usTonSquareInchTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
 public final class com/splendo/kaluga/scientific/converter/radioactivity/ConvertFromAmountOfSubstanceAndTimeKt {
@@ -4424,9 +4494,14 @@ public final class com/splendo/kaluga/scientific/converter/volume/ConvertToWeigh
 	public static final fun volumeTimesDensity (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
-public final class com/splendo/kaluga/scientific/converter/volumetricFlow/ConvertFromVolumeAndTimeKt {
+public final class com/splendo/kaluga/scientific/converter/volumetricFlow/ConvertFromPowerAndPressureKt {
 	public static final fun volumetricFlowFromVolumeAndTime (Lcom/splendo/kaluga/scientific/unit/VolumetricFlow;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
 	public static final fun volumetricFlowFromVolumeAndTimeDefault (Lcom/splendo/kaluga/scientific/unit/VolumetricFlow;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
+public final class com/splendo/kaluga/scientific/converter/volumetricFlow/ConvertFromVolumeAndTimeKt {
+	public static final fun volumetricFlowFromPowerAndPressure (Lcom/splendo/kaluga/scientific/unit/VolumetricFlow;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
+	public static final fun volumetricFlowFromPowerAndPressureDefault (Lcom/splendo/kaluga/scientific/unit/VolumetricFlow;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
 public final class com/splendo/kaluga/scientific/converter/volumetricFlow/ConvertFromVolumetricFluxAndAreaKt {
@@ -4444,6 +4519,31 @@ public final class com/splendo/kaluga/scientific/converter/volumetricFlow/Conver
 	public static final fun usCustomaryVolumetricFlowDivImperialVolumetricFlux (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 	public static final fun usCustomaryVolumetricFlowDivUSCustomaryVolumetricFlux (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 	public static final fun volumetricFlowDivVolumetricFlux (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
+public final class com/splendo/kaluga/scientific/converter/volumetricFlow/ConvertToPowerKt {
+	public static final fun imperialVolumetricFlowTimesImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialVolumetricFlowTimesKilopoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialVolumetricFlowTimesOunceSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialVolumetricFlowTimesPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialVolumetricFlowTimesUkImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialVolumetricFlowTimesUsCustomaryPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun metricVolumetricFlowTimesBarye (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun metricVolumetricFlowTimesBaryeMultiple (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun uKImperialVolumetricFlowTimesImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun uKImperialVolumetricFlowTimesPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun uKImperialVolumetricFlowTimesUkImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun uSCustomaryVolumetricFlowTimesImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun uSCustomaryVolumetricFlowTimesPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun uSCustomaryVolumetricFlowTimesUsCustomaryPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ukImperialVolumetricFlowTimesImperialTonSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ukImperialVolumetricFlowTimesKilopoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ukImperialVolumetricFlowTimesOunceSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usCustomaryVolumetricFlowTimesKilopoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usCustomaryVolumetricFlowTimesKipSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usCustomaryVolumetricFlowTimesOunceSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usCustomaryVolumetricFlowTimesUsTonSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun volumeTimesPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
 public final class com/splendo/kaluga/scientific/converter/volumetricFlow/ConvertToVolumeKt {

--- a/scientific/api/jvm/scientific.api
+++ b/scientific/api/jvm/scientific.api
@@ -3356,13 +3356,18 @@ public final class com/splendo/kaluga/scientific/converter/momentum/ConvertToWei
 }
 
 public final class com/splendo/kaluga/scientific/converter/power/ConvertFromEnergyAndTimeKt {
-	public static final fun powerFromEnergyAndTime (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
-	public static final fun powerFromEnergyAndTimeDefault (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun powerFromPressureAndVolumetricFlow (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
+	public static final fun powerFromPressureAndVolumetricFlowDefault (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
 public final class com/splendo/kaluga/scientific/converter/power/ConvertFromForceAndSpeedKt {
 	public static final fun powerFromForceAndSpeed (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
 	public static final fun powerFromForceAndSpeedDefault (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
+public final class com/splendo/kaluga/scientific/converter/power/ConvertFromPressureAndVolumetricFlowKt {
+	public static final fun powerFromEnergyAndTime (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
+	public static final fun powerFromEnergyAndTimeDefault (Lcom/splendo/kaluga/scientific/unit/Power;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
 public final class com/splendo/kaluga/scientific/converter/power/ConvertFromTemperatureAndThermalResistanceKt {
@@ -3409,6 +3414,17 @@ public final class com/splendo/kaluga/scientific/converter/power/ConvertToForceK
 	public static final fun powerDivSpeed (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
+public final class com/splendo/kaluga/scientific/converter/power/ConvertToPressureKt {
+	public static final fun imperialCombinedPowerDivImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun metricCombinedPowerDivMetricVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun powerDivVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
 public final class com/splendo/kaluga/scientific/converter/power/ConvertToSpeedKt {
 	public static final fun imperialCombinedPowerDivImperialForce (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 	public static final fun imperialPowerDivImperialForce (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
@@ -3440,6 +3456,30 @@ public final class com/splendo/kaluga/scientific/converter/power/ConvertToVoltag
 	public static final fun powerDivCurrent (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
+public final class com/splendo/kaluga/scientific/converter/power/ConvertToVolumetricFlowKt {
+	public static final fun imperialCombinedPowerDivImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivImperialTonSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivKiloPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivKipSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivOunceSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivUKImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivUsCustomaryPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialCombinedPowerDivUsTonSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivImperialTonSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivKiloPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivKipSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivOunceSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivUKImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivUsCustomaryPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPowerDivUsTonSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun metricCombinedPowerDivBarye (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun metricCombinedPowerDivBaryeMultiple (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun powerDivPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
 public final class com/splendo/kaluga/scientific/converter/pressure/ConvertFromDynamicViscosityAndTimeKt {
 	public static final fun pressureFromDynamicViscosityAndTime (Lcom/splendo/kaluga/scientific/unit/Pressure;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
 	public static final fun pressureFromDynamicViscosityAndTimeDefault (Lcom/splendo/kaluga/scientific/unit/Pressure;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
@@ -3453,6 +3493,11 @@ public final class com/splendo/kaluga/scientific/converter/pressure/ConvertFromE
 public final class com/splendo/kaluga/scientific/converter/pressure/ConvertFromForceAndAreaKt {
 	public static final fun pressureFromForceAndArea (Lcom/splendo/kaluga/scientific/unit/Pressure;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
 	public static final fun pressureFromForceAndAreaDefault (Lcom/splendo/kaluga/scientific/unit/Pressure;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
+public final class com/splendo/kaluga/scientific/converter/pressure/ConvertFromPowerAndVolumetricFlowKt {
+	public static final fun pressureFromPowerAndVolumetricFlow (Lcom/splendo/kaluga/scientific/unit/Pressure;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
+	public static final fun pressureFromPowerAndVolumetricFlowDefault (Lcom/splendo/kaluga/scientific/unit/Pressure;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
 public final class com/splendo/kaluga/scientific/converter/pressure/ConvertToDynamicViscosityKt {
@@ -3497,6 +3542,31 @@ public final class com/splendo/kaluga/scientific/converter/pressure/ConvertToFor
 	public static final fun usCustomaryPressureTimesImperialArea (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 	public static final fun usTonSquareFeetTimesImperialArea (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 	public static final fun usTonSquareInchTimesImperialArea (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
+public final class com/splendo/kaluga/scientific/converter/pressure/ConvertToPowerKt {
+	public static final fun baryeMultipleTimesMetricVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun baryeTimesMetricVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPressureTimesImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPressureTimesUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialPressureTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialTonSquareInchTimesUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun kilopoundSquareInchTimesImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun kilopoundSquareInchTimesUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun kilopoundSquareInchTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun kipSquareInchTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ounceSquareInchTimesImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ounceSquareInchTimesUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ounceSquareInchTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun poundSquareInchTimesImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun poundSquareInchTimesUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun poundSquareInchTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun pressureTimesVolume (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ukImperialPressureTimesImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ukImperialPressureTimesUKImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usCustomaryPressureTimesImperialVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usCustomaryPressureTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usTonSquareInchTimesUSCustomaryVolumetricFlow (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
 public final class com/splendo/kaluga/scientific/converter/radioactivity/ConvertFromAmountOfSubstanceAndTimeKt {
@@ -4424,9 +4494,14 @@ public final class com/splendo/kaluga/scientific/converter/volume/ConvertToWeigh
 	public static final fun volumeTimesDensity (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
-public final class com/splendo/kaluga/scientific/converter/volumetricFlow/ConvertFromVolumeAndTimeKt {
+public final class com/splendo/kaluga/scientific/converter/volumetricFlow/ConvertFromPowerAndPressureKt {
 	public static final fun volumetricFlowFromVolumeAndTime (Lcom/splendo/kaluga/scientific/unit/VolumetricFlow;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
 	public static final fun volumetricFlowFromVolumeAndTimeDefault (Lcom/splendo/kaluga/scientific/unit/VolumetricFlow;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
+public final class com/splendo/kaluga/scientific/converter/volumetricFlow/ConvertFromVolumeAndTimeKt {
+	public static final fun volumetricFlowFromPowerAndPressure (Lcom/splendo/kaluga/scientific/unit/VolumetricFlow;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;Lkotlin/jvm/functions/Function2;)Lcom/splendo/kaluga/scientific/ScientificValue;
+	public static final fun volumetricFlowFromPowerAndPressureDefault (Lcom/splendo/kaluga/scientific/unit/VolumetricFlow;Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
 public final class com/splendo/kaluga/scientific/converter/volumetricFlow/ConvertFromVolumetricFluxAndAreaKt {
@@ -4444,6 +4519,31 @@ public final class com/splendo/kaluga/scientific/converter/volumetricFlow/Conver
 	public static final fun usCustomaryVolumetricFlowDivImperialVolumetricFlux (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 	public static final fun usCustomaryVolumetricFlowDivUSCustomaryVolumetricFlux (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 	public static final fun volumetricFlowDivVolumetricFlux (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+}
+
+public final class com/splendo/kaluga/scientific/converter/volumetricFlow/ConvertToPowerKt {
+	public static final fun imperialVolumetricFlowTimesImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialVolumetricFlowTimesKilopoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialVolumetricFlowTimesOunceSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialVolumetricFlowTimesPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialVolumetricFlowTimesUkImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun imperialVolumetricFlowTimesUsCustomaryPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun metricVolumetricFlowTimesBarye (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun metricVolumetricFlowTimesBaryeMultiple (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun uKImperialVolumetricFlowTimesImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun uKImperialVolumetricFlowTimesPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun uKImperialVolumetricFlowTimesUkImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun uSCustomaryVolumetricFlowTimesImperialPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun uSCustomaryVolumetricFlowTimesPoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun uSCustomaryVolumetricFlowTimesUsCustomaryPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ukImperialVolumetricFlowTimesImperialTonSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ukImperialVolumetricFlowTimesKilopoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun ukImperialVolumetricFlowTimesOunceSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usCustomaryVolumetricFlowTimesKilopoundSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usCustomaryVolumetricFlowTimesKipSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usCustomaryVolumetricFlowTimesOunceSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun usCustomaryVolumetricFlowTimesUsTonSquareInch (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
+	public static final fun volumeTimesPressure (Lcom/splendo/kaluga/scientific/ScientificValue;Lcom/splendo/kaluga/scientific/ScientificValue;)Lcom/splendo/kaluga/scientific/DefaultScientificValue;
 }
 
 public final class com/splendo/kaluga/scientific/converter/volumetricFlow/ConvertToVolumeKt {

--- a/scientific/src/commonMain/kotlin/converter/power/convertFromPressureAndVolumetricFlow.kt
+++ b/scientific/src/commonMain/kotlin/converter/power/convertFromPressureAndVolumetricFlow.kt
@@ -21,30 +21,30 @@ import com.splendo.kaluga.base.utils.Decimal
 import com.splendo.kaluga.scientific.DefaultScientificValue
 import com.splendo.kaluga.scientific.PhysicalQuantity
 import com.splendo.kaluga.scientific.ScientificValue
-import com.splendo.kaluga.scientific.byMultiplying
+import com.splendo.kaluga.scientific.byDividing
+import com.splendo.kaluga.scientific.unit.Energy
 import com.splendo.kaluga.scientific.unit.Power
-import com.splendo.kaluga.scientific.unit.Pressure
-import com.splendo.kaluga.scientific.unit.VolumetricFlow
+import com.splendo.kaluga.scientific.unit.Time
 import kotlin.jvm.JvmName
 
-@JvmName("powerFromPressureAndVolumetricFlowDefault")
+@JvmName("powerFromEnergyAndTimeDefault")
 fun <
-    PressureUnit : Pressure,
-    VolumetricFlowUnit : VolumetricFlow,
+    EnergyUnit : Energy,
+    TimeUnit : Time,
     PowerUnit : Power,
     > PowerUnit.power(
-    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
-    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, VolumetricFlowUnit>,
-) = power(pressure, volumetricFlow, ::DefaultScientificValue)
+    energy: ScientificValue<PhysicalQuantity.Energy, EnergyUnit>,
+    time: ScientificValue<PhysicalQuantity.Time, TimeUnit>,
+) = power(energy, time, ::DefaultScientificValue)
 
-@JvmName("powerFromPressureAndVolumetricFlow")
+@JvmName("powerFromEnergyAndTime")
 fun <
-    PressureUnit : Pressure,
-    VolumetricFlowUnit : VolumetricFlow,
+    EnergyUnit : Energy,
+    TimeUnit : Time,
     PowerUnit : Power,
     Value : ScientificValue<PhysicalQuantity.Power, PowerUnit>,
     > PowerUnit.power(
-    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
-    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, VolumetricFlowUnit>,
+    energy: ScientificValue<PhysicalQuantity.Energy, EnergyUnit>,
+    time: ScientificValue<PhysicalQuantity.Time, TimeUnit>,
     factory: (Decimal, PowerUnit) -> Value,
-) = byMultiplying(pressure, volumetricFlow, factory)
+) = byDividing(energy, time, factory)

--- a/scientific/src/commonMain/kotlin/converter/power/convertFromPressureAndVolumetricFlow.kt
+++ b/scientific/src/commonMain/kotlin/converter/power/convertFromPressureAndVolumetricFlow.kt
@@ -1,5 +1,5 @@
 /*
- Copyright 2022 Splendo Consulting B.V. The Netherlands
+ Copyright 2025 Splendo Consulting B.V. The Netherlands
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/scientific/src/commonMain/kotlin/converter/power/convertToPressure.kt
+++ b/scientific/src/commonMain/kotlin/converter/power/convertToPressure.kt
@@ -1,0 +1,73 @@
+/*
+ Copyright 2025 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.scientific.converter.power
+
+import com.splendo.kaluga.scientific.PhysicalQuantity
+import com.splendo.kaluga.scientific.ScientificValue
+import com.splendo.kaluga.scientific.converter.pressure.pressure
+import com.splendo.kaluga.scientific.unit.Barye
+import com.splendo.kaluga.scientific.unit.ImperialCombinedPower
+import com.splendo.kaluga.scientific.unit.ImperialPower
+import com.splendo.kaluga.scientific.unit.ImperialVolumetricFlow
+import com.splendo.kaluga.scientific.unit.MetricCombinedPower
+import com.splendo.kaluga.scientific.unit.MetricVolumetricFlow
+import com.splendo.kaluga.scientific.unit.Pascal
+import com.splendo.kaluga.scientific.unit.PoundSquareInch
+import com.splendo.kaluga.scientific.unit.Power
+import com.splendo.kaluga.scientific.unit.UKImperialVolumetricFlow
+import com.splendo.kaluga.scientific.unit.USCustomaryVolumetricFlow
+import com.splendo.kaluga.scientific.unit.VolumetricFlow
+import com.splendo.kaluga.scientific.unit.ukImperial
+import com.splendo.kaluga.scientific.unit.usCustomary
+import kotlin.jvm.JvmName
+
+@JvmName("metricCombinedPowerDivMetricVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Power, MetricCombinedPower>.div(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, MetricVolumetricFlow>) =
+    Barye.pressure(this, volumetricFlow)
+
+@JvmName("imperialCombinedPowerDivImperialVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Power, ImperialCombinedPower>.div(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>) =
+    PoundSquareInch.pressure(this, volumetricFlow)
+
+@JvmName("imperialCombinedPowerDivUKImperialVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Power, ImperialCombinedPower>.div(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>) =
+    PoundSquareInch.ukImperial.pressure(this, volumetricFlow)
+
+@JvmName("imperialCombinedPowerDivUSCustomaryVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Power, ImperialCombinedPower>.div(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>) =
+    PoundSquareInch.usCustomary.pressure(this, volumetricFlow)
+
+@JvmName("imperialPowerDivImperialVolumetricFlow")
+infix operator fun <PowerUnit : ImperialPower> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>,
+) = PoundSquareInch.pressure(this, volumetricFlow)
+
+@JvmName("imperialPowerDivUKImperialVolumetricFlow")
+infix operator fun <PowerUnit : ImperialPower> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>,
+) = PoundSquareInch.ukImperial.pressure(this, volumetricFlow)
+
+@JvmName("imperialPowerDivUSCustomaryVolumetricFlow")
+infix operator fun <PowerUnit : ImperialPower> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>,
+) = PoundSquareInch.usCustomary.pressure(this, volumetricFlow)
+
+@JvmName("powerDivVolumetricFlow")
+infix operator fun <PowerUnit : Power, VolumetricFlowUnit : VolumetricFlow> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, VolumetricFlowUnit>,
+) = Pascal.pressure(this, volumetricFlow)

--- a/scientific/src/commonMain/kotlin/converter/power/convertToVolumetricFlow.kt
+++ b/scientific/src/commonMain/kotlin/converter/power/convertToVolumetricFlow.kt
@@ -1,0 +1,182 @@
+/*
+ Copyright 2025 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.scientific.converter.power
+
+import com.splendo.kaluga.scientific.PhysicalQuantity
+import com.splendo.kaluga.scientific.ScientificValue
+import com.splendo.kaluga.scientific.converter.volumetricFlow.volumetricFlow
+import com.splendo.kaluga.scientific.unit.Barye
+import com.splendo.kaluga.scientific.unit.BaryeMultiple
+import com.splendo.kaluga.scientific.unit.CubicCentimeter
+import com.splendo.kaluga.scientific.unit.CubicFoot
+import com.splendo.kaluga.scientific.unit.CubicInch
+import com.splendo.kaluga.scientific.unit.CubicMeter
+import com.splendo.kaluga.scientific.unit.ImperialCombinedPower
+import com.splendo.kaluga.scientific.unit.ImperialPower
+import com.splendo.kaluga.scientific.unit.ImperialPressure
+import com.splendo.kaluga.scientific.unit.ImperialTonSquareInch
+import com.splendo.kaluga.scientific.unit.KiloPoundSquareInch
+import com.splendo.kaluga.scientific.unit.KipSquareInch
+import com.splendo.kaluga.scientific.unit.MetricCombinedPower
+import com.splendo.kaluga.scientific.unit.OunceSquareInch
+import com.splendo.kaluga.scientific.unit.PoundSquareInch
+import com.splendo.kaluga.scientific.unit.Power
+import com.splendo.kaluga.scientific.unit.Pressure
+import com.splendo.kaluga.scientific.unit.Second
+import com.splendo.kaluga.scientific.unit.UKImperialPressure
+import com.splendo.kaluga.scientific.unit.USCustomaryPressure
+import com.splendo.kaluga.scientific.unit.USTonSquareInch
+import com.splendo.kaluga.scientific.unit.per
+import kotlin.jvm.JvmName
+
+@JvmName("metricCombinedPowerDivBarye")
+infix operator fun ScientificValue<PhysicalQuantity.Power, MetricCombinedPower>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, Barye>) =
+    (CubicCentimeter per unit.per).volumetricFlow(this, pressure)
+
+@JvmName("metricCombinedPowerDivBaryeMultiple")
+infix operator fun <BaryeUnit : BaryeMultiple> ScientificValue<PhysicalQuantity.Power, MetricCombinedPower>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, BaryeUnit>) = (
+    CubicCentimeter per
+        unit.per
+    ).volumetricFlow(this, pressure)
+
+@JvmName("imperialCombinedPowerDivPoundSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.Power, ImperialCombinedPower>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, PoundSquareInch>) = (
+    CubicInch per
+        unit.per
+    ).volumetricFlow(this, pressure)
+
+@JvmName("imperialCombinedPowerDivOunceSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.Power, ImperialCombinedPower>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, OunceSquareInch>) = (
+    CubicInch per
+        unit.per
+    ).volumetricFlow(this, pressure)
+
+@JvmName("imperialCombinedPowerDivKiloPoundSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.Power, ImperialCombinedPower>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, KiloPoundSquareInch>) = (
+    CubicInch per
+        unit.per
+    ).volumetricFlow(this, pressure)
+
+@JvmName("imperialCombinedPowerDivKipSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.Power, ImperialCombinedPower>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, KipSquareInch>) =
+    (CubicInch per unit.per).usCustomary.volumetricFlow(this, pressure)
+
+@JvmName("imperialCombinedPowerDivUsTonSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.Power, ImperialCombinedPower>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, USTonSquareInch>) = (
+    CubicInch per
+        unit.per
+    ).usCustomary.volumetricFlow(this, pressure)
+
+@JvmName("imperialCombinedPowerDivImperialTonSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.Power, ImperialCombinedPower>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, ImperialTonSquareInch>) = (
+    CubicInch per
+        unit.per
+    ).ukImperial.volumetricFlow(this, pressure)
+
+@JvmName("imperialCombinedPowerDivImperialPressure")
+infix operator fun <PressureUnit : ImperialPressure> ScientificValue<PhysicalQuantity.Power, ImperialCombinedPower>.div(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = (
+    CubicFoot per
+        unit.per
+    ).volumetricFlow(this, pressure)
+
+@JvmName("imperialCombinedPowerDivUKImperialPressure")
+infix operator fun <PressureUnit : UKImperialPressure> ScientificValue<PhysicalQuantity.Power, ImperialCombinedPower>.div(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = (
+    CubicFoot per
+        unit.per
+    ).ukImperial.volumetricFlow(this, pressure)
+
+@JvmName("imperialCombinedPowerDivUsCustomaryPressure")
+infix operator fun <PressureUnit : USCustomaryPressure> ScientificValue<PhysicalQuantity.Power, ImperialCombinedPower>.div(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = (
+    CubicFoot per
+        unit.per
+    ).usCustomary.volumetricFlow(this, pressure)
+
+@JvmName("imperialPowerDivPoundSquareInch")
+infix operator fun <PowerUnit : ImperialPower> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, PoundSquareInch>) = (
+    CubicInch per
+        Second
+    ).volumetricFlow(this, pressure)
+
+@JvmName("imperialPowerDivOunceSquareInch")
+infix operator fun <PowerUnit : ImperialPower> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, OunceSquareInch>) = (
+    CubicInch per
+        Second
+    ).volumetricFlow(this, pressure)
+
+@JvmName("imperialPowerDivKiloPoundSquareInch")
+infix operator fun <PowerUnit : ImperialPower> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, KiloPoundSquareInch>) = (
+    CubicInch per
+        Second
+    ).volumetricFlow(this, pressure)
+
+@JvmName("imperialPowerDivKipSquareInch")
+infix operator fun <PowerUnit : ImperialPower> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, KipSquareInch>) = (
+    CubicInch per
+        Second
+    ).usCustomary.volumetricFlow(this, pressure)
+
+@JvmName("imperialPowerDivUsTonSquareInch")
+infix operator fun <PowerUnit : ImperialPower> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, USTonSquareInch>) = (
+    CubicInch per
+        Second
+    ).usCustomary.volumetricFlow(this, pressure)
+
+@JvmName("imperialPowerDivImperialTonSquareInch")
+infix operator fun <PowerUnit : ImperialPower> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(pressure: ScientificValue<PhysicalQuantity.Pressure, ImperialTonSquareInch>) =
+    (
+        CubicInch per
+            Second
+        ).ukImperial.volumetricFlow(this, pressure)
+
+@JvmName("imperialPowerDivImperialPressure")
+infix operator fun <PowerUnit : ImperialPower, PressureUnit : ImperialPressure> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = (
+    CubicFoot per
+        Second
+    ).volumetricFlow(this, pressure)
+
+@JvmName("imperialPowerDivUKImperialPressure")
+infix operator fun <PowerUnit : ImperialPower, PressureUnit : UKImperialPressure> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = (
+    CubicFoot per
+        Second
+    ).ukImperial.volumetricFlow(this, pressure)
+
+@JvmName("imperialPowerDivUsCustomaryPressure")
+infix operator fun <PowerUnit : ImperialPower, PressureUnit : USCustomaryPressure> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = (
+    CubicFoot per
+        Second
+    ).usCustomary.volumetricFlow(this, pressure)
+
+@JvmName("powerDivPressure")
+infix operator fun <PowerUnit : Power, PressureUnit : Pressure> ScientificValue<PhysicalQuantity.Power, PowerUnit>.div(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = (
+    CubicMeter per
+        Second
+    ).volumetricFlow(this, pressure)

--- a/scientific/src/commonMain/kotlin/converter/pressure/convertFromPowerAndVolumetricFlow.kt
+++ b/scientific/src/commonMain/kotlin/converter/pressure/convertFromPowerAndVolumetricFlow.kt
@@ -15,36 +15,36 @@
 
  */
 
-package com.splendo.kaluga.scientific.converter.power
+package com.splendo.kaluga.scientific.converter.pressure
 
 import com.splendo.kaluga.base.utils.Decimal
 import com.splendo.kaluga.scientific.DefaultScientificValue
 import com.splendo.kaluga.scientific.PhysicalQuantity
 import com.splendo.kaluga.scientific.ScientificValue
-import com.splendo.kaluga.scientific.byMultiplying
+import com.splendo.kaluga.scientific.byDividing
 import com.splendo.kaluga.scientific.unit.Power
 import com.splendo.kaluga.scientific.unit.Pressure
 import com.splendo.kaluga.scientific.unit.VolumetricFlow
 import kotlin.jvm.JvmName
 
-@JvmName("powerFromPressureAndVolumetricFlowDefault")
+@JvmName("pressureFromPowerAndVolumetricFlowDefault")
 fun <
-    PressureUnit : Pressure,
-    VolumetricFlowUnit : VolumetricFlow,
     PowerUnit : Power,
-    > PowerUnit.power(
-    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+    VolumetricFlowUnit : VolumetricFlow,
+    PressureUnit : Pressure,
+    > PressureUnit.pressure(
+    power: ScientificValue<PhysicalQuantity.Power, PowerUnit>,
     volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, VolumetricFlowUnit>,
-) = power(pressure, volumetricFlow, ::DefaultScientificValue)
+) = pressure(power, volumetricFlow, ::DefaultScientificValue)
 
-@JvmName("powerFromPressureAndVolumetricFlow")
+@JvmName("pressureFromPowerAndVolumetricFlow")
 fun <
-    PressureUnit : Pressure,
-    VolumetricFlowUnit : VolumetricFlow,
     PowerUnit : Power,
-    Value : ScientificValue<PhysicalQuantity.Power, PowerUnit>,
-    > PowerUnit.power(
-    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+    VolumetricFlowUnit : VolumetricFlow,
+    PressureUnit : Pressure,
+    Value : ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+    > PressureUnit.pressure(
+    power: ScientificValue<PhysicalQuantity.Power, PowerUnit>,
     volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, VolumetricFlowUnit>,
-    factory: (Decimal, PowerUnit) -> Value,
-) = byMultiplying(pressure, volumetricFlow, factory)
+    factory: (Decimal, PressureUnit) -> Value,
+) = byDividing(power, volumetricFlow, factory)

--- a/scientific/src/commonMain/kotlin/converter/pressure/convertFromPowerAndVolumetricFlow.kt
+++ b/scientific/src/commonMain/kotlin/converter/pressure/convertFromPowerAndVolumetricFlow.kt
@@ -1,5 +1,5 @@
 /*
- Copyright 2022 Splendo Consulting B.V. The Netherlands
+ Copyright 2025 Splendo Consulting B.V. The Netherlands
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/scientific/src/commonMain/kotlin/converter/pressure/convertToPower.kt
+++ b/scientific/src/commonMain/kotlin/converter/pressure/convertToPower.kt
@@ -1,0 +1,148 @@
+/*
+ Copyright 2022 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.scientific.converter.pressure
+
+import com.splendo.kaluga.scientific.PhysicalQuantity
+import com.splendo.kaluga.scientific.ScientificValue
+import com.splendo.kaluga.scientific.converter.power.power
+import com.splendo.kaluga.scientific.unit.Barye
+import com.splendo.kaluga.scientific.unit.BaryeMultiple
+import com.splendo.kaluga.scientific.unit.Erg
+import com.splendo.kaluga.scientific.unit.FootPoundForce
+import com.splendo.kaluga.scientific.unit.ImperialPressure
+import com.splendo.kaluga.scientific.unit.ImperialTonSquareInch
+import com.splendo.kaluga.scientific.unit.ImperialVolumetricFlow
+import com.splendo.kaluga.scientific.unit.InchOunceForce
+import com.splendo.kaluga.scientific.unit.InchPoundForce
+import com.splendo.kaluga.scientific.unit.KiloPoundSquareInch
+import com.splendo.kaluga.scientific.unit.KipSquareInch
+import com.splendo.kaluga.scientific.unit.MetricVolumetricFlow
+import com.splendo.kaluga.scientific.unit.OunceSquareInch
+import com.splendo.kaluga.scientific.unit.PoundSquareInch
+import com.splendo.kaluga.scientific.unit.Pressure
+import com.splendo.kaluga.scientific.unit.UKImperialPressure
+import com.splendo.kaluga.scientific.unit.UKImperialVolumetricFlow
+import com.splendo.kaluga.scientific.unit.USCustomaryPressure
+import com.splendo.kaluga.scientific.unit.USCustomaryVolumetricFlow
+import com.splendo.kaluga.scientific.unit.USTonSquareInch
+import com.splendo.kaluga.scientific.unit.VolumetricFlow
+import com.splendo.kaluga.scientific.unit.Watt
+import com.splendo.kaluga.scientific.unit.per
+import kotlin.jvm.JvmName
+
+@JvmName("baryeTimesMetricVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Pressure, Barye>.times(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, MetricVolumetricFlow>) = (
+    Erg per
+        volumetricFlow.unit.per
+    ).power(this, volumetricFlow)
+
+@JvmName("baryeMultipleTimesMetricVolumetricFlow")
+infix operator fun <BaryeUnit : BaryeMultiple> ScientificValue<PhysicalQuantity.Pressure, BaryeUnit>.times(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, MetricVolumetricFlow>,
+) = (Erg per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("poundSquareInchTimesImperialVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Pressure, PoundSquareInch>.times(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>) =
+    (InchPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("poundSquareInchTimesUKImperialVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Pressure, PoundSquareInch>.times(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>) =
+    (InchPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("poundSquareInchTimesUSCustomaryVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Pressure, PoundSquareInch>.times(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>) =
+    (InchPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("ounceSquareInchTimesImperialVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Pressure, OunceSquareInch>.times(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>) =
+    (InchOunceForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("ounceSquareInchTimesUKImperialVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Pressure, OunceSquareInch>.times(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>) =
+    (InchOunceForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("ounceSquareInchTimesUSCustomaryVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Pressure, OunceSquareInch>.times(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>) =
+    (InchOunceForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("kilopoundSquareInchTimesImperialVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Pressure, KiloPoundSquareInch>.times(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>) =
+    (InchPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("kilopoundSquareInchTimesUKImperialVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Pressure, KiloPoundSquareInch>.times(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>,
+) = (InchPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("kilopoundSquareInchTimesUSCustomaryVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Pressure, KiloPoundSquareInch>.times(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>,
+) = (InchPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("kipSquareInchTimesUSCustomaryVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Pressure, KipSquareInch>.times(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>) =
+    (InchPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("usTonSquareInchTimesUSCustomaryVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Pressure, USTonSquareInch>.times(volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>) =
+    (InchPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("imperialTonSquareInchTimesUKImperialVolumetricFlow")
+infix operator fun ScientificValue<PhysicalQuantity.Pressure, ImperialTonSquareInch>.times(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>,
+) = (InchPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("imperialPressureTimesImperialVolumetricFlow")
+infix operator fun <PressureUnit : ImperialPressure> ScientificValue<PhysicalQuantity.Pressure, PressureUnit>.times(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>,
+) = (FootPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("imperialPressureTimesUKImperialVolumetricFlow")
+infix operator fun <PressureUnit : ImperialPressure> ScientificValue<PhysicalQuantity.Pressure, PressureUnit>.times(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>,
+) = (FootPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("imperialPressureTimesUSCustomaryVolumetricFlow")
+infix operator fun <PressureUnit : ImperialPressure> ScientificValue<PhysicalQuantity.Pressure, PressureUnit>.times(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>,
+) = (FootPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("ukImperialPressureTimesImperialVolumetricFlow")
+infix operator fun <PressureUnit : UKImperialPressure> ScientificValue<PhysicalQuantity.Pressure, PressureUnit>.times(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>,
+) = (FootPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("ukImperialPressureTimesUKImperialVolumetricFlow")
+infix operator fun <PressureUnit : UKImperialPressure> ScientificValue<PhysicalQuantity.Pressure, PressureUnit>.times(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>,
+) = (FootPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("usCustomaryPressureTimesImperialVolumetricFlow")
+infix operator fun <PressureUnit : USCustomaryPressure> ScientificValue<PhysicalQuantity.Pressure, PressureUnit>.times(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>,
+) = (FootPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("usCustomaryPressureTimesUSCustomaryVolumetricFlow")
+infix operator fun <PressureUnit : USCustomaryPressure> ScientificValue<PhysicalQuantity.Pressure, PressureUnit>.times(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>,
+) = (FootPoundForce per volumetricFlow.unit.per).power(this, volumetricFlow)
+
+@JvmName("pressureTimesVolume")
+infix operator fun <PressureUnit : Pressure, VolumetricFlowUnit : VolumetricFlow> ScientificValue<PhysicalQuantity.Pressure, PressureUnit>.times(
+    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, VolumetricFlowUnit>,
+) = Watt.power(this, volumetricFlow)

--- a/scientific/src/commonMain/kotlin/converter/pressure/convertToPower.kt
+++ b/scientific/src/commonMain/kotlin/converter/pressure/convertToPower.kt
@@ -1,5 +1,5 @@
 /*
- Copyright 2022 Splendo Consulting B.V. The Netherlands
+ Copyright 2025 Splendo Consulting B.V. The Netherlands
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/scientific/src/commonMain/kotlin/converter/volumetricFlow/convertFromPowerAndPressure.kt
+++ b/scientific/src/commonMain/kotlin/converter/volumetricFlow/convertFromPowerAndPressure.kt
@@ -15,36 +15,36 @@
 
  */
 
-package com.splendo.kaluga.scientific.converter.power
+package com.splendo.kaluga.scientific.converter.volumetricFlow
 
 import com.splendo.kaluga.base.utils.Decimal
 import com.splendo.kaluga.scientific.DefaultScientificValue
 import com.splendo.kaluga.scientific.PhysicalQuantity
 import com.splendo.kaluga.scientific.ScientificValue
-import com.splendo.kaluga.scientific.byMultiplying
-import com.splendo.kaluga.scientific.unit.Power
-import com.splendo.kaluga.scientific.unit.Pressure
+import com.splendo.kaluga.scientific.byDividing
+import com.splendo.kaluga.scientific.unit.Time
+import com.splendo.kaluga.scientific.unit.Volume
 import com.splendo.kaluga.scientific.unit.VolumetricFlow
 import kotlin.jvm.JvmName
 
-@JvmName("powerFromPressureAndVolumetricFlowDefault")
+@JvmName("volumetricFlowFromVolumeAndTimeDefault")
 fun <
-    PressureUnit : Pressure,
+    VolumeUnit : Volume,
+    TimeUnit : Time,
     VolumetricFlowUnit : VolumetricFlow,
-    PowerUnit : Power,
-    > PowerUnit.power(
-    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
-    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, VolumetricFlowUnit>,
-) = power(pressure, volumetricFlow, ::DefaultScientificValue)
+    > VolumetricFlowUnit.volumetricFlow(
+    volume: ScientificValue<PhysicalQuantity.Volume, VolumeUnit>,
+    time: ScientificValue<PhysicalQuantity.Time, TimeUnit>,
+) = volumetricFlow(volume, time, ::DefaultScientificValue)
 
-@JvmName("powerFromPressureAndVolumetricFlow")
+@JvmName("volumetricFlowFromVolumeAndTime")
 fun <
-    PressureUnit : Pressure,
+    VolumeUnit : Volume,
+    TimeUnit : Time,
     VolumetricFlowUnit : VolumetricFlow,
-    PowerUnit : Power,
-    Value : ScientificValue<PhysicalQuantity.Power, PowerUnit>,
-    > PowerUnit.power(
-    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
-    volumetricFlow: ScientificValue<PhysicalQuantity.VolumetricFlow, VolumetricFlowUnit>,
-    factory: (Decimal, PowerUnit) -> Value,
-) = byMultiplying(pressure, volumetricFlow, factory)
+    Value : ScientificValue<PhysicalQuantity.VolumetricFlow, VolumetricFlowUnit>,
+    > VolumetricFlowUnit.volumetricFlow(
+    volume: ScientificValue<PhysicalQuantity.Volume, VolumeUnit>,
+    time: ScientificValue<PhysicalQuantity.Time, TimeUnit>,
+    factory: (Decimal, VolumetricFlowUnit) -> Value,
+) = byDividing(volume, time, factory)

--- a/scientific/src/commonMain/kotlin/converter/volumetricFlow/convertFromPowerAndPressure.kt
+++ b/scientific/src/commonMain/kotlin/converter/volumetricFlow/convertFromPowerAndPressure.kt
@@ -1,5 +1,5 @@
 /*
- Copyright 2022 Splendo Consulting B.V. The Netherlands
+ Copyright 2025 Splendo Consulting B.V. The Netherlands
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/scientific/src/commonMain/kotlin/converter/volumetricFlow/convertFromVolumeAndTime.kt
+++ b/scientific/src/commonMain/kotlin/converter/volumetricFlow/convertFromVolumeAndTime.kt
@@ -22,29 +22,29 @@ import com.splendo.kaluga.scientific.DefaultScientificValue
 import com.splendo.kaluga.scientific.PhysicalQuantity
 import com.splendo.kaluga.scientific.ScientificValue
 import com.splendo.kaluga.scientific.byDividing
-import com.splendo.kaluga.scientific.unit.Time
-import com.splendo.kaluga.scientific.unit.Volume
+import com.splendo.kaluga.scientific.unit.Power
+import com.splendo.kaluga.scientific.unit.Pressure
 import com.splendo.kaluga.scientific.unit.VolumetricFlow
 import kotlin.jvm.JvmName
 
-@JvmName("volumetricFlowFromVolumeAndTimeDefault")
+@JvmName("volumetricFlowFromPowerAndPressureDefault")
 fun <
-    VolumeUnit : Volume,
-    TimeUnit : Time,
+    PowerUnit : Power,
+    PressureUnit : Pressure,
     VolumetricFlowUnit : VolumetricFlow,
     > VolumetricFlowUnit.volumetricFlow(
-    volume: ScientificValue<PhysicalQuantity.Volume, VolumeUnit>,
-    time: ScientificValue<PhysicalQuantity.Time, TimeUnit>,
-) = volumetricFlow(volume, time, ::DefaultScientificValue)
+    power: ScientificValue<PhysicalQuantity.Power, PowerUnit>,
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = volumetricFlow(power, pressure, ::DefaultScientificValue)
 
-@JvmName("volumetricFlowFromVolumeAndTime")
+@JvmName("volumetricFlowFromPowerAndPressure")
 fun <
-    VolumeUnit : Volume,
-    TimeUnit : Time,
+    PowerUnit : Power,
+    PressureUnit : Pressure,
     VolumetricFlowUnit : VolumetricFlow,
     Value : ScientificValue<PhysicalQuantity.VolumetricFlow, VolumetricFlowUnit>,
     > VolumetricFlowUnit.volumetricFlow(
-    volume: ScientificValue<PhysicalQuantity.Volume, VolumeUnit>,
-    time: ScientificValue<PhysicalQuantity.Time, TimeUnit>,
+    power: ScientificValue<PhysicalQuantity.Power, PowerUnit>,
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
     factory: (Decimal, VolumetricFlowUnit) -> Value,
-) = byDividing(volume, time, factory)
+) = byDividing(power, pressure, factory)

--- a/scientific/src/commonMain/kotlin/converter/volumetricFlow/convertToPower.kt
+++ b/scientific/src/commonMain/kotlin/converter/volumetricFlow/convertToPower.kt
@@ -1,0 +1,136 @@
+/*
+ Copyright 2022 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.scientific.converter.volumetricFlow
+
+import com.splendo.kaluga.scientific.PhysicalQuantity
+import com.splendo.kaluga.scientific.ScientificValue
+import com.splendo.kaluga.scientific.converter.pressure.times
+import com.splendo.kaluga.scientific.unit.Barye
+import com.splendo.kaluga.scientific.unit.BaryeMultiple
+import com.splendo.kaluga.scientific.unit.ImperialPressure
+import com.splendo.kaluga.scientific.unit.ImperialTonSquareInch
+import com.splendo.kaluga.scientific.unit.ImperialVolumetricFlow
+import com.splendo.kaluga.scientific.unit.KiloPoundSquareInch
+import com.splendo.kaluga.scientific.unit.KipSquareInch
+import com.splendo.kaluga.scientific.unit.MetricVolumetricFlow
+import com.splendo.kaluga.scientific.unit.OunceSquareInch
+import com.splendo.kaluga.scientific.unit.PoundSquareInch
+import com.splendo.kaluga.scientific.unit.Pressure
+import com.splendo.kaluga.scientific.unit.UKImperialPressure
+import com.splendo.kaluga.scientific.unit.UKImperialVolumetricFlow
+import com.splendo.kaluga.scientific.unit.USCustomaryPressure
+import com.splendo.kaluga.scientific.unit.USCustomaryVolumetricFlow
+import com.splendo.kaluga.scientific.unit.USTonSquareInch
+import com.splendo.kaluga.scientific.unit.VolumetricFlow
+import kotlin.jvm.JvmName
+
+@JvmName("metricVolumetricFlowTimesBarye")
+infix operator fun ScientificValue<PhysicalQuantity.VolumetricFlow, MetricVolumetricFlow>.times(pressure: ScientificValue<PhysicalQuantity.Pressure, Barye>) = pressure * this
+
+@JvmName("metricVolumetricFlowTimesBaryeMultiple")
+infix operator fun <BaryeUnit : BaryeMultiple> ScientificValue<PhysicalQuantity.VolumetricFlow, MetricVolumetricFlow>.times(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, BaryeUnit>,
+) = pressure * this
+
+@JvmName("imperialVolumetricFlowTimesPoundSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>.times(pressure: ScientificValue<PhysicalQuantity.Pressure, PoundSquareInch>) =
+    pressure * this
+
+@JvmName("uKImperialVolumetricFlowTimesPoundSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>.times(pressure: ScientificValue<PhysicalQuantity.Pressure, PoundSquareInch>) =
+    pressure * this
+
+@JvmName("uSCustomaryVolumetricFlowTimesPoundSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>.times(pressure: ScientificValue<PhysicalQuantity.Pressure, PoundSquareInch>) =
+    pressure * this
+
+@JvmName("imperialVolumetricFlowTimesOunceSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>.times(pressure: ScientificValue<PhysicalQuantity.Pressure, OunceSquareInch>) =
+    pressure * this
+
+@JvmName("ukImperialVolumetricFlowTimesOunceSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>.times(pressure: ScientificValue<PhysicalQuantity.Pressure, OunceSquareInch>) =
+    pressure * this
+
+@JvmName("usCustomaryVolumetricFlowTimesOunceSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>.times(pressure: ScientificValue<PhysicalQuantity.Pressure, OunceSquareInch>) =
+    pressure * this
+
+@JvmName("imperialVolumetricFlowTimesKilopoundSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>.times(pressure: ScientificValue<PhysicalQuantity.Pressure, KiloPoundSquareInch>) =
+    pressure * this
+
+@JvmName("ukImperialVolumetricFlowTimesKilopoundSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>.times(pressure: ScientificValue<PhysicalQuantity.Pressure, KiloPoundSquareInch>) =
+    pressure * this
+
+@JvmName("usCustomaryVolumetricFlowTimesKilopoundSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>.times(pressure: ScientificValue<PhysicalQuantity.Pressure, KiloPoundSquareInch>) =
+    pressure * this
+
+@JvmName("usCustomaryVolumetricFlowTimesKipSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>.times(pressure: ScientificValue<PhysicalQuantity.Pressure, KipSquareInch>) =
+    pressure * this
+
+@JvmName("usCustomaryVolumetricFlowTimesUsTonSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>.times(pressure: ScientificValue<PhysicalQuantity.Pressure, USTonSquareInch>) =
+    pressure * this
+
+@JvmName("ukImperialVolumetricFlowTimesImperialTonSquareInch")
+infix operator fun ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>.times(pressure: ScientificValue<PhysicalQuantity.Pressure, ImperialTonSquareInch>) =
+    pressure * this
+
+@JvmName("imperialVolumetricFlowTimesImperialPressure")
+infix operator fun <PressureUnit : ImperialPressure> ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>.times(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = pressure * this
+
+@JvmName("uKImperialVolumetricFlowTimesImperialPressure")
+infix operator fun <PressureUnit : ImperialPressure> ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>.times(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = pressure * this
+
+@JvmName("uSCustomaryVolumetricFlowTimesImperialPressure")
+infix operator fun <PressureUnit : ImperialPressure> ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>.times(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = pressure * this
+
+@JvmName("imperialVolumetricFlowTimesUkImperialPressure")
+infix operator fun <PressureUnit : UKImperialPressure> ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>.times(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = pressure * this
+
+@JvmName("uKImperialVolumetricFlowTimesUkImperialPressure")
+infix operator fun <PressureUnit : UKImperialPressure> ScientificValue<PhysicalQuantity.VolumetricFlow, UKImperialVolumetricFlow>.times(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = pressure * this
+
+@JvmName("imperialVolumetricFlowTimesUsCustomaryPressure")
+infix operator fun <PressureUnit : USCustomaryPressure> ScientificValue<PhysicalQuantity.VolumetricFlow, ImperialVolumetricFlow>.times(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = pressure * this
+
+@JvmName("uSCustomaryVolumetricFlowTimesUsCustomaryPressure")
+infix operator fun <PressureUnit : USCustomaryPressure> ScientificValue<PhysicalQuantity.VolumetricFlow, USCustomaryVolumetricFlow>.times(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = pressure * this
+
+@JvmName("volumeTimesPressure")
+infix operator fun <PressureUnit : Pressure, VolumetricFlowUnit : VolumetricFlow> ScientificValue<PhysicalQuantity.VolumetricFlow, VolumetricFlowUnit>.times(
+    pressure: ScientificValue<PhysicalQuantity.Pressure, PressureUnit>,
+) = pressure * this

--- a/scientific/src/commonMain/kotlin/converter/volumetricFlow/convertToPower.kt
+++ b/scientific/src/commonMain/kotlin/converter/volumetricFlow/convertToPower.kt
@@ -1,5 +1,5 @@
 /*
- Copyright 2022 Splendo Consulting B.V. The Netherlands
+ Copyright 2025 Splendo Consulting B.V. The Netherlands
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/scientific/src/commonTest/kotlin/unit/PowerUnitTest.kt
+++ b/scientific/src/commonTest/kotlin/unit/PowerUnitTest.kt
@@ -22,10 +22,12 @@ import com.splendo.kaluga.scientific.convert
 import com.splendo.kaluga.scientific.converter.electricCurrent.times
 import com.splendo.kaluga.scientific.converter.energy.div
 import com.splendo.kaluga.scientific.converter.force.times
+import com.splendo.kaluga.scientific.converter.pressure.times
 import com.splendo.kaluga.scientific.converter.speed.times
 import com.splendo.kaluga.scientific.converter.temperature.deltaValue
 import com.splendo.kaluga.scientific.converter.temperature.div
 import com.splendo.kaluga.scientific.converter.voltage.times
+import com.splendo.kaluga.scientific.converter.volumetricFlow.times
 import com.splendo.kaluga.scientific.invoke
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -159,6 +161,54 @@ class PowerUnitTest {
         assertEquals(4(FootPoundForce per Second), 2(Foot per Second) * 2(PoundForce.usCustomary))
         assertEqualScientificValue(4(Watt), 2(Newton).convert(PoundForce) * 2(Meter per Second))
         assertEqualScientificValue(4(Watt), 2(Meter per Second) * 2(Newton).convert(PoundForce))
+    }
+
+    @Test
+    fun powerFromPressureAndVolumetricFlowTest() {
+        assertEqualScientificValue(4(Erg per Minute), 2(Barye) * 2(CubicCentimeter per Minute))
+        assertEqualScientificValue(4(Erg per Minute), 2(CubicCentimeter per Minute) * 2(Barye))
+        assertEqualScientificValue(4(Erg per Minute), 20(Decibarye) * 2(CubicCentimeter per Minute))
+        assertEqualScientificValue(4(Erg per Minute), 2(CubicCentimeter per Minute) * 20(Decibarye))
+        assertEqualScientificValue(4(InchPoundForce per Minute), 2(PoundSquareInch) * 2(CubicInch per Minute))
+        assertEqualScientificValue(4(InchPoundForce per Minute), 2(CubicInch per Minute) * 2(PoundSquareInch))
+        assertEqualScientificValue(4(InchPoundForce per Minute), 2(PoundSquareInch) * 2(CubicInch.ukImperial per Minute))
+        assertEqualScientificValue(4(InchPoundForce per Minute), 2(CubicInch.ukImperial per Minute) * 2(PoundSquareInch))
+        assertEqualScientificValue(4(InchPoundForce per Minute), 2(PoundSquareInch) * 2(CubicInch.usCustomary per Minute))
+        assertEqualScientificValue(4(InchPoundForce per Minute), 2(CubicInch.usCustomary per Minute) * 2(PoundSquareInch))
+        assertEqualScientificValue(4(InchOunceForce per Minute), 2(OunceSquareInch) * 2(CubicInch per Minute))
+        assertEqualScientificValue(4(InchOunceForce per Minute), 2(CubicInch per Minute) * 2(OunceSquareInch))
+        assertEqualScientificValue(4(InchOunceForce per Minute), 2(OunceSquareInch) * 2(CubicInch.ukImperial per Minute))
+        assertEqualScientificValue(4(InchOunceForce per Minute), 2(CubicInch.ukImperial per Minute) * 2(OunceSquareInch))
+        assertEqualScientificValue(4(InchOunceForce per Minute), 2(OunceSquareInch) * 2(CubicInch.usCustomary per Minute))
+        assertEqualScientificValue(4(InchOunceForce per Minute), 2(CubicInch.usCustomary per Minute) * 2(OunceSquareInch))
+        assertEqualScientificValue(4000(InchPoundForce per Minute), 2(KiloPoundSquareInch) * 2(CubicInch per Minute))
+        assertEqualScientificValue(4000(InchPoundForce per Minute), 2(CubicInch per Minute) * 2(KiloPoundSquareInch))
+        assertEqualScientificValue(4000(InchPoundForce per Minute), 2(KiloPoundSquareInch) * 2(CubicInch.ukImperial per Minute))
+        assertEqualScientificValue(4000(InchPoundForce per Minute), 2(CubicInch.ukImperial per Minute) * 2(KiloPoundSquareInch))
+        assertEqualScientificValue(4000(InchPoundForce per Minute), 2(KiloPoundSquareInch) * 2(CubicInch.usCustomary per Minute))
+        assertEqualScientificValue(4000(InchPoundForce per Minute), 2(CubicInch.usCustomary per Minute) * 2(KiloPoundSquareInch))
+        assertEqualScientificValue(4000(InchPoundForce per Minute), 2(KipSquareInch) * 2(CubicInch.usCustomary per Minute))
+        assertEqualScientificValue(4000(InchPoundForce per Minute), 2(CubicInch.usCustomary per Minute) * 2(KipSquareInch))
+        assertEqualScientificValue(8000(InchPoundForce per Minute), 2(USTonSquareInch) * 2(CubicInch.usCustomary per Minute))
+        assertEqualScientificValue(8000(InchPoundForce per Minute), 2(CubicInch.usCustomary per Minute) * 2(USTonSquareInch))
+        assertEqualScientificValue(8960(InchPoundForce per Minute), 2(ImperialTonSquareInch) * 2(CubicInch.ukImperial per Minute))
+        assertEqualScientificValue(8960(InchPoundForce per Minute), 2(CubicInch.ukImperial per Minute) * 2(ImperialTonSquareInch))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(PoundSquareFoot) * 2(CubicFoot per Minute))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(CubicFoot per Minute) * 2(PoundSquareFoot))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(PoundSquareFoot) * 2(CubicFoot.ukImperial per Minute))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(CubicFoot.ukImperial per Minute) * 2(PoundSquareFoot))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(PoundSquareFoot) * 2(CubicFoot.usCustomary per Minute))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(CubicFoot.usCustomary per Minute) * 2(PoundSquareFoot))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(PoundSquareFoot.ukImperial) * 2(CubicFoot per Minute))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(CubicFoot per Minute) * 2(PoundSquareFoot.ukImperial))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(PoundSquareFoot.ukImperial) * 2(CubicFoot.ukImperial per Minute))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(CubicFoot.ukImperial per Minute) * 2(PoundSquareFoot.ukImperial))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(PoundSquareFoot.usCustomary) * 2(CubicFoot per Minute))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(CubicFoot per Minute) * 2(PoundSquareFoot.usCustomary))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(PoundSquareFoot.usCustomary) * 2(CubicFoot.usCustomary per Minute))
+        assertEqualScientificValue(4(FootPoundForce per Minute), 2(CubicFoot.usCustomary per Minute) * 2(PoundSquareFoot.usCustomary))
+        assertEqualScientificValue(4(Watt), 2(Pascal) * 2(CubicMeter per Second))
+        assertEqualScientificValue(4(Watt), 2(CubicMeter per Second) * 2(Pascal))
     }
 
     @Test

--- a/scientific/src/commonTest/kotlin/unit/PressureUnitTest.kt
+++ b/scientific/src/commonTest/kotlin/unit/PressureUnitTest.kt
@@ -22,6 +22,7 @@ import com.splendo.kaluga.scientific.convert
 import com.splendo.kaluga.scientific.converter.dynamicViscosity.div
 import com.splendo.kaluga.scientific.converter.energy.div
 import com.splendo.kaluga.scientific.converter.force.div
+import com.splendo.kaluga.scientific.converter.power.div
 import com.splendo.kaluga.scientific.invoke
 import kotlin.test.Test
 
@@ -214,5 +215,17 @@ class PressureUnitTest {
             2(PoundForce.usCustomary) / 2(SquareInch),
         )
         assertEqualScientificValue(1(Pascal), 2(Newton) / 2(SquareMeter).convert(SquareFoot))
+    }
+
+    @Test
+    fun pressureFromPowerAndVolumetricFlowTest() {
+        assertEqualScientificValue(1(Barye), 2(Erg per Second) / 2(CubicCentimeter per Second))
+        assertEqualScientificValue(1(PoundSquareInch), 2(InchPoundForce per Second) / 2(CubicInch per Second))
+        assertEqualScientificValue(1(PoundSquareInch.ukImperial), 2(InchPoundForce per Second) / 2(CubicInch.ukImperial per Second))
+        assertEqualScientificValue(1(PoundSquareInch.usCustomary), 2(InchPoundForce per Second) / 2(CubicInch.usCustomary per Second))
+        assertEqualScientificValue(6600(PoundSquareInch), 2(Horsepower) / 2(CubicInch per Second))
+        assertEqualScientificValue(6600(PoundSquareInch.ukImperial), 2(Horsepower) / 2(CubicInch.ukImperial per Second))
+        assertEqualScientificValue(6600(PoundSquareInch.usCustomary), 2(Horsepower) / 2(CubicInch.usCustomary per Second))
+        assertEqualScientificValue(1(Pascal), 2(Watt) / 2(CubicMeter per Second))
     }
 }

--- a/scientific/src/commonTest/kotlin/unit/VolumetricFlowUnitTest.kt
+++ b/scientific/src/commonTest/kotlin/unit/VolumetricFlowUnitTest.kt
@@ -17,8 +17,10 @@
 
 package com.splendo.kaluga.scientific.unit
 
+import com.splendo.kaluga.scientific.assertEqualScientificValue
 import com.splendo.kaluga.scientific.convert
 import com.splendo.kaluga.scientific.converter.area.times
+import com.splendo.kaluga.scientific.converter.power.div
 import com.splendo.kaluga.scientific.converter.volume.div
 import com.splendo.kaluga.scientific.converter.volumetricFlux.times
 import com.splendo.kaluga.scientific.invoke
@@ -86,5 +88,30 @@ class VolumetricFlowUnitTest {
             4(CubicMeter per Second),
             2(SquareMeter).convert(SquareFoot) * 2((CubicMeter per Second) per SquareMeter),
         )
+    }
+
+    @Test
+    fun volumetricFlowFromPowerAndPressureTest() {
+        assertEqualScientificValue(1(CubicCentimeter per Minute), 2(Erg per Minute) / 2(Barye))
+        assertEqualScientificValue(1(CubicCentimeter per Minute), 2(Erg per Minute) / 20(Decibarye))
+        assertEqualScientificValue(1(CubicInch per Minute), 2(InchPoundForce per Minute) / 2(PoundSquareInch))
+        assertEqualScientificValue(1(CubicInch per Minute), 2(InchOunceForce per Minute) / 2(OunceSquareInch))
+        assertEqualScientificValue(0.001(CubicInch per Minute), 2(InchPoundForce per Minute) / 2(KiloPoundSquareInch))
+        assertEqualScientificValue(0.001(CubicInch.usCustomary per Minute), 2(InchPoundForce per Minute) / 2(KipSquareInch))
+        assertEqualScientificValue(5.0e-4(CubicInch.usCustomary per Minute), 2(InchPoundForce per Minute) / 2(USTonSquareInch))
+        assertEqualScientificValue(4.46429e-4(CubicInch.ukImperial per Minute), 2(InchPoundForce per Minute) / 2(ImperialTonSquareInch), 5)
+        assertEqualScientificValue(1(CubicFoot per Minute), 2(FootPoundForce per Minute) / 2(PoundSquareFoot))
+        assertEqualScientificValue(1(CubicFoot.ukImperial per Minute), 2(FootPoundForce per Minute) / 2(PoundSquareFoot.ukImperial))
+        assertEqualScientificValue(1(CubicFoot.usCustomary per Minute), 2(FootPoundForce per Minute) / 2(PoundSquareFoot.usCustomary))
+        assertEqualScientificValue(6600(CubicInch per Second), 2(Horsepower) / 2(PoundSquareInch))
+        assertEqualScientificValue(105600(CubicInch per Second), 2(Horsepower) / 2(OunceSquareInch))
+        assertEqualScientificValue(6.6(CubicInch per Second), 2(Horsepower) / 2(KiloPoundSquareInch))
+        assertEqualScientificValue(6.6(CubicInch.usCustomary per Second), 2(Horsepower) / 2(KipSquareInch))
+        assertEqualScientificValue(3.3(CubicInch.usCustomary per Second), 2(Horsepower) / 2(USTonSquareInch))
+        assertEqualScientificValue(2.946429(CubicInch.ukImperial per Second), 2(Horsepower) / 2(ImperialTonSquareInch), 6)
+        assertEqualScientificValue(550(CubicFoot per Second), 2(Horsepower) / 2(PoundSquareFoot))
+        assertEqualScientificValue(550(CubicFoot.ukImperial per Second), 2(Horsepower) / 2(PoundSquareFoot.ukImperial))
+        assertEqualScientificValue(550(CubicFoot.usCustomary per Second), 2(Horsepower) / 2(PoundSquareFoot.usCustomary))
+        assertEqualScientificValue(1(CubicMeter per Second), 2(Watt) / 2(Pascal))
     }
 }


### PR DESCRIPTION
Given that Power is defined as
`kg m2 s-3`
Pressure is
`kg m-1 s-2`
And Volumetric Flow is
`m3 s-1`
It follows that
Power = Pressure * Volumetric Flow

This operator is currently missing from the scientific library