### PR TITLE
Fix duplicate location permission in AndroidManifest

### DIFF
--- a/location/src/androidMain/AndroidManifest.xml
+++ b/location/src/androidMain/AndroidManifest.xml
@@ -1,8 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="ACCESS_FINE_LOCATION" />
-
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-
+    
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />


### PR DESCRIPTION
Remove warning during compilation

`> Task :composeApp:processDebugMainManifest
[com.splendo.kaluga:location-android-debug:1.5.1] /Users/jiaco/.gradle/caches/8.13/transforms/a284bef0f59fba984f6a361c1c86b17d/transformed/location-debug/AndroidManifest.xml:9:5-81 Warning:
	Element uses-permission#android.permission.ACCESS_COARSE_LOCATION at [com.splendo.kaluga:location-android-debug:1.5.1] AndroidManifest.xml:9:5-81 duplicated with element declared at [com.splendo.kaluga:location-android-debug:1.5.1] AndroidManifest.xml:8:5-81
`
