### PR TITLE
Use PAT in rerun workflow

### DIFF
--- a/.github/workflows/rerun_emulator.yaml
+++ b/.github/workflows/rerun_emulator.yaml
@@ -1,6 +1,7 @@
 name: Rerun failed emulator tests
 permissions:
   contents: write
+  actions: write
   
 on:
   workflow_run:
@@ -12,11 +13,11 @@ jobs:
   on-failure:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt < 2 }}
-    env: 
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      # Re-running another workflow's run is not possible with the installation-scoped
+      # GITHUB_TOKEN ("Resource not accessible by integration"), so this needs a PAT
+      # with actions read/write on this repository.
+      GH_TOKEN: ${{ secrets.RERUN_PAT }}
+      GH_REPO: ${{ github.repository }}
     steps:
-      - name: checkout 
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
       - run: gh run rerun ${{ github.event.workflow_run.id }} --failed


### PR DESCRIPTION
The rerun workflow has failed on every invocation with "Resource not accessible by integration": the installation-scoped GITHUB_TOKEN cannot rerun another workflow's run regardless of the actions: write permission. It now uses the RERUN_PAT repository secret (a classic PAT with public_repo scope, already configured — that scope was verified sufficient against the rerun-failed-jobs endpoint). The recursive submodule checkout is dropped too, since gh run rerun never needed a checkout at all.

Cherry-picked from feature/js-base (#940): workflow_run-triggered workflows always execute the default branch's workflow file, so the fix is inert until it lands on develop.