### PR TITLE
Upgrade CI tooling and cancel superseded Apple runs

### DIFF
--- a/.github/workflows/apple.yaml
+++ b/.github/workflows/apple.yaml
@@ -1,6 +1,11 @@
 name: Apple tests
 on: pull_request
 
+# macOS runners are a scarce, expensive pool; cancel superseded runs on a new push to free them.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     uses: ./.github/workflows/setup_macos.yaml

--- a/.github/workflows/setup_tools_linux/action.yaml
+++ b/.github/workflows/setup_tools_linux/action.yaml
@@ -22,7 +22,7 @@ runs:
         java-version: 21
 
     - name: Gradle cache
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6
       with:
         cache-read-only: ${{ inputs.gradle-cache-read-only }}
         gradle-home-cache-includes: |

--- a/.github/workflows/setup_tools_macos/action.yaml
+++ b/.github/workflows/setup_tools_macos/action.yaml
@@ -29,7 +29,7 @@ runs:
         xcode-version: '26.3'
 
     - name: Gradle cache
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6
       with:
         cache-read-only: ${{ inputs.gradle-cache-read-only }}
         gradle-home-cache-includes: |

--- a/.github/workflows/setup_tools_macos/action.yaml
+++ b/.github/workflows/setup_tools_macos/action.yaml
@@ -26,7 +26,7 @@ runs:
     - name: use Xcode 26
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '26.3'
+        xcode-version: '26.5'
 
     - name: Gradle cache
       uses: gradle/actions/setup-gradle@v6


### PR DESCRIPTION
Bumps gradle/actions to v6, whose enhanced cache provider (free for public repositories) deduplicates the Gradle dependency caches that dominate the repository's cache quota.

Adds concurrency with cancel-in-progress to the Apple test workflow so a new push cancels superseded runs and frees the scarce macOS runner pool instead of letting them finish.

Upgrades the CI Xcode from 26.3 to 26.5.
