### PR TITLE
Make NumberFormatter and KalugaDateFormatter thread-safe

### DIFF
--- a/base/formatting/src/androidMain/kotlin/formatting/NumberFormatter.kt
+++ b/base/formatting/src/androidMain/kotlin/formatting/NumberFormatter.kt
@@ -76,9 +76,18 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         is NumberFormatStyle.Pattern -> DecimalFormat("${style.positivePattern};${style.negativePattern}", DecimalFormatSymbols(locale.locale))
     } as DecimalFormat
 
+    // DecimalFormat is not thread-safe: format and parse share its internal digit buffer, so racing
+    // them on one instance corrupts results. Parsing therefore gets its own instance, making
+    // format/parse cross-contamination impossible while each path pays only a single (typically
+    // uncontended) monitor. The instances double as the locks, so they must stay private and never
+    // escape this class. Configuration writes go through [update] to both instances so the
+    // format/parse round-trip stays consistent.
+    private val parser = format.clone() as DecimalFormat
+
     // When the Scientific style sets a decimal-notation threshold, values within the threshold are
     // rendered with this plain decimal formatter instead; its mutable state is synced from `format`
-    // at format time so symbol/grouping overrides apply to both notations.
+    // at format time so symbol/grouping overrides apply to both notations. It is only ever touched
+    // while holding the `format` monitor.
     private val decimalThresholdStyle: NumberFormatStyle.Scientific? =
         (style as? NumberFormatStyle.Scientific)?.takeIf { it.maxExponentForDecimalNotation != null }
     private val decimalFallback: DecimalFormat? = decimalThresholdStyle?.decimalNotation?.let { decimal ->
@@ -90,7 +99,9 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         }
     }
 
-    private val symbols: DecimalFormatSymbols get() = format.decimalFormatSymbols
+    // DecimalFormat.getDecimalFormatSymbols returns a copy, so it is safe to read outside the lock
+    // once obtained.
+    private val symbols: DecimalFormatSymbols get() = read { it.decimalFormatSymbols }
     init {
         val javaRounding = when (style.roundingMode) {
             RoundingMode.Ceiling -> java.math.RoundingMode.CEILING
@@ -102,6 +113,7 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
             RoundingMode.Up -> java.math.RoundingMode.UP
         }
         format.roundingMode = javaRounding
+        parser.roundingMode = javaRounding
         decimalFallback?.roundingMode = javaRounding
     }
 
@@ -153,24 +165,24 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         }
 
     actual override var positivePrefix: String
-        get() = format.positivePrefix
+        get() = read { it.positivePrefix }
         set(value) {
-            format.positivePrefix = value
+            update { it.positivePrefix = value }
         }
     actual override var positiveSuffix: String
-        get() = format.positiveSuffix
+        get() = read { it.positiveSuffix }
         set(value) {
-            format.positiveSuffix = value
+            update { it.positiveSuffix = value }
         }
     actual override var negativePrefix: String
-        get() = format.negativePrefix
+        get() = read { it.negativePrefix }
         set(value) {
-            format.negativePrefix = value
+            update { it.negativePrefix = value }
         }
     actual override var negativeSuffix: String
-        get() = format.negativeSuffix
+        get() = read { it.negativeSuffix }
         set(value) {
-            format.negativeSuffix = value
+            update { it.negativeSuffix = value }
         }
 
     actual override var groupingSeparator: Char
@@ -181,10 +193,15 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
     actual override var usesGroupingSeparator: Boolean
         // The decimal fallback owns grouping so it groups like a normal decimal by default; the toggle
         // drives both notations.
-        get() = (decimalFallback ?: format).isGroupingUsed
+        get() = read { (decimalFallback ?: it).isGroupingUsed }
         set(value) {
-            format.isGroupingUsed = value
-            decimalFallback?.isGroupingUsed = value
+            synchronized(format) {
+                synchronized(parser) {
+                    format.isGroupingUsed = value
+                    parser.isGroupingUsed = value
+                }
+                decimalFallback?.isGroupingUsed = value
+            }
         }
     actual override var decimalSeparator: Char
         get() = symbols.decimalSeparator
@@ -192,9 +209,9 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
             applySymbols { it.decimalSeparator = value }
         }
     actual override var alwaysShowsDecimalSeparator: Boolean
-        get() = format.isDecimalSeparatorAlwaysShown
+        get() = read { it.isDecimalSeparatorAlwaysShown }
         set(value) {
-            format.isDecimalSeparatorAlwaysShown = value
+            update { it.isDecimalSeparatorAlwaysShown = value }
         }
     actual override var currencyDecimalSeparator: Char
         get() = symbols.monetaryDecimalSeparator
@@ -203,22 +220,27 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         }
     actual override var groupingSize: Int
         // The decimal fallback owns its grouping size (the scientific pattern has none); the setter drives both.
-        get() = (decimalFallback ?: format).groupingSize
+        get() = read { (decimalFallback ?: it).groupingSize }
         set(value) {
-            format.groupingSize = value
-            decimalFallback?.groupingSize = value
+            synchronized(format) {
+                synchronized(parser) {
+                    format.groupingSize = value
+                    parser.groupingSize = value
+                }
+                decimalFallback?.groupingSize = value
+            }
         }
     actual override var multiplier: Int
-        get() = format.multiplier
+        get() = read { it.multiplier }
         set(value) {
-            format.multiplier = value
+            update { it.multiplier = value }
         }
 
-    actual override fun format(number: Number): String {
+    actual override fun format(number: Number): String = synchronized(format) {
         val value = number.toDouble()
         val fallback = decimalFallback
         val scientific = decimalThresholdStyle
-        return if (fallback != null && scientific != null && scientific.rendersAsDecimal(value)) {
+        if (fallback != null && scientific != null && scientific.rendersAsDecimal(value)) {
             // Sync everything except grouping (which the fallback owns — see usesGroupingSeparator/groupingSize —
             // so it renders like a normal localized decimal regardless of scientific's no-grouping default).
             fallback.decimalFormatSymbols = format.decimalFormatSymbols
@@ -233,14 +255,26 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
             format.format(value)
         }
     }
-    actual override fun parse(string: String): Number? = try {
-        format.parse(string)
-    } catch (e: ParseException) {
-        null
+    actual override fun parse(string: String): Number? = synchronized(parser) {
+        try {
+            parser.parse(string)
+        } catch (e: ParseException) {
+            null
+        }
     }
-    private fun applySymbols(apply: (DecimalFormatSymbols) -> Unit) {
-        val symbols = format.decimalFormatSymbols
+    private inline fun <T> read(action: (DecimalFormat) -> T): T = synchronized(format) { action(format) }
+
+    // Nested in a fixed order (format then parse) so writes cannot deadlock and neither instance is
+    // observed mid-update by format or parse.
+    private inline fun update(action: (DecimalFormat) -> Unit) = synchronized(format) {
+        synchronized(parser) {
+            action(format)
+            action(parser)
+        }
+    }
+    private fun applySymbols(apply: (DecimalFormatSymbols) -> Unit) = update {
+        val symbols = it.decimalFormatSymbols
         apply(symbols)
-        format.decimalFormatSymbols = symbols
+        it.decimalFormatSymbols = symbols
     }
 }

--- a/base/formatting/src/apple64BitMain/kotlin/formatting/NumberFormatter.kt
+++ b/base/formatting/src/apple64BitMain/kotlin/formatting/NumberFormatter.kt
@@ -116,8 +116,9 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
     }
 
     // When the Scientific style sets a decimal-notation threshold, values within the threshold are
-    // rendered with this plain decimal formatter instead; its mutable state is synced from `formatter`
-    // at format time so symbol/grouping overrides apply to both notations.
+    // rendered with this plain decimal formatter instead; it is synced from `formatter` once at
+    // construction and kept in sync by the property setters, so format never mutates it —
+    // NSNumberFormatter is only documented thread-safe for non-mutating use.
     private val decimalThresholdStyle: NumberFormatStyle.Scientific? =
         (style as? NumberFormatStyle.Scientific)?.takeIf { it.maxExponentForDecimalNotation != null }
     private val decimalFallback: NSNumberFormatter? = decimalThresholdStyle?.decimalNotation?.let { decimal ->
@@ -133,6 +134,12 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         }
     }
 
+    init {
+        decimalFallback?.let(::syncDecimalFallback)
+    }
+
+    // Construction-time only: copies the locale defaults the fallback shares with `formatter`. After
+    // this the property setters write through to both.
     private fun syncDecimalFallback(target: NSNumberFormatter) {
         target.decimalSeparator = formatter.decimalSeparator
         target.groupingSeparator = formatter.groupingSeparator
@@ -162,7 +169,9 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
     actual override var minusSign: Char
         get() = formatter.minusSign.getOrNull(0) ?: Char.MIN_VALUE
         set(value) {
-            formatter.minusSign = charArrayOf(value).concatToString()
+            val charValue = charArrayOf(value).concatToString()
+            formatter.minusSign = charValue
+            decimalFallback?.minusSign = charValue
         }
     actual override var exponentSymbol: String
         get() = formatter.exponentSymbol
@@ -172,18 +181,23 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
     actual override var zeroSymbol: Char
         get() = formatter.zeroSymbol?.getOrNull(0) ?: '0'
         set(value) {
-            formatter.zeroSymbol = charArrayOf(value).concatToString()
+            val charValue = charArrayOf(value).concatToString()
+            formatter.zeroSymbol = charValue
+            decimalFallback?.zeroSymbol = charValue
         }
     actual override var notANumberSymbol: String
         get() = formatter.notANumberSymbol
         set(value) {
             formatter.notANumberSymbol = value
+            decimalFallback?.notANumberSymbol = value
         }
     actual override var infinitySymbol: String
         get() = formatter.positiveInfinitySymbol
         set(value) {
             formatter.positiveInfinitySymbol = value
             formatter.negativeInfinitySymbol = value
+            decimalFallback?.positiveInfinitySymbol = value
+            decimalFallback?.negativeInfinitySymbol = value
         }
     actual override var currencySymbol: String
         get() = formatter.currencySymbol
@@ -199,21 +213,25 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         get() = formatter.positivePrefix
         set(value) {
             formatter.positivePrefix = value
+            decimalFallback?.positivePrefix = value
         }
     actual override var positiveSuffix: String
         get() = formatter.positiveSuffix
         set(value) {
             formatter.positiveSuffix = value
+            decimalFallback?.positiveSuffix = value
         }
     actual override var negativePrefix: String
         get() = formatter.negativePrefix
         set(value) {
             formatter.negativePrefix = value
+            decimalFallback?.negativePrefix = value
         }
     actual override var negativeSuffix: String
         get() = formatter.negativeSuffix
         set(value) {
             formatter.negativeSuffix = value
+            decimalFallback?.negativeSuffix = value
         }
     actual override var groupingSeparator: Char
         get() = formatter.groupingSeparator.getOrNull(0) ?: Char.MIN_VALUE
@@ -221,6 +239,7 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
             val charValue = charArrayOf(value).concatToString()
             formatter.groupingSeparator = charValue
             formatter.currencyGroupingSeparator = charValue
+            decimalFallback?.groupingSeparator = charValue
         }
     actual override var usesGroupingSeparator: Boolean
         // The decimal fallback owns grouping so it groups like a normal decimal by default; the toggle
@@ -233,12 +252,15 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
     actual override var decimalSeparator: Char
         get() = formatter.decimalSeparator.getOrNull(0) ?: Char.MIN_VALUE
         set(value) {
-            formatter.decimalSeparator = charArrayOf(value).concatToString()
+            val charValue = charArrayOf(value).concatToString()
+            formatter.decimalSeparator = charValue
+            decimalFallback?.decimalSeparator = charValue
         }
     actual override var alwaysShowsDecimalSeparator: Boolean
         get() = formatter.alwaysShowsDecimalSeparator
         set(value) {
             formatter.alwaysShowsDecimalSeparator = value
+            decimalFallback?.alwaysShowsDecimalSeparator = value
         }
     actual override var currencyDecimalSeparator: Char
         get() = formatter.currencyDecimalSeparator.getOrNull(0) ?: Char.MIN_VALUE
@@ -259,7 +281,9 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
     actual override var multiplier: Int
         get() = formatter.multiplier?.intValue ?: 1
         set(value) {
-            formatter.multiplier = NSNumber.numberWithInt(value)
+            val multiplierValue = NSNumber.numberWithInt(value)
+            formatter.multiplier = multiplierValue
+            decimalFallback?.multiplier = multiplierValue
         }
 
     @Suppress("CAST_NEVER_SUCCEEDS") // Should succeed just fine
@@ -267,7 +291,6 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         val fallback = decimalFallback
         val scientific = decimalThresholdStyle
         if (fallback != null && scientific != null && scientific.rendersAsDecimal(number.toDouble())) {
-            syncDecimalFallback(fallback)
             return fallback.stringFromNumber(number as NSNumber) ?: ""
         }
         return formatter.stringFromNumber(number as NSNumber) ?: ""

--- a/base/formatting/src/commonTest/kotlin/formatting/NumberFormatterConcurrencyTest.kt
+++ b/base/formatting/src/commonTest/kotlin/formatting/NumberFormatterConcurrencyTest.kt
@@ -77,4 +77,50 @@ class NumberFormatterConcurrencyTest : BaseTest() {
             "${failures.size} corrupted results out of ${WORKERS * ITERATIONS * 2} operations; first: ${failures.take(5)}",
         )
     }
+
+    @Test
+    fun testSharedScientificFormatterWithDecimalThresholdFormatsCorrectlyUnderContention() = testRunBlocking {
+        // Values straddle maxExponentForDecimalNotation so the decimal-fallback path and the plain
+        // scientific path run concurrently on the shared formatter.
+        val formatter = NumberFormatter(createLocale("en", "US"), NumberFormatStyle.Scientific(maxExponentForDecimalNotation = 6U))
+
+        // Establish the single-threaded expectations first, so a failure below can only mean corruption.
+        assertEquals("1,000.0", formatter.format(1000))
+        assertEquals("12,345.678", formatter.format(12345.678))
+        assertEquals("1.0E7", formatter.format(10000000))
+        assertEquals("1.0E-7", formatter.format(0.0000001))
+
+        val failures = (0 until WORKERS).map { worker ->
+            async(Dispatchers.Default) {
+                val workerFailures = mutableListOf<String>()
+
+                // A formatter torn mid-reconfiguration may throw rather than corrupt, so exceptions
+                // count as corruption too.
+                fun expect(operation: String, expected: String, actual: () -> String) {
+                    val result = try {
+                        actual()
+                    } catch (e: Throwable) {
+                        "threw $e"
+                    }
+                    if (result != expected) workerFailures.add("$operation -> $result")
+                }
+                repeat(ITERATIONS) { iteration ->
+                    // Alternate which path goes first per worker so fallback and scientific overlap.
+                    if ((worker + iteration) % 2 == 0) {
+                        expect("format(1000)", "1,000.0") { formatter.format(1000) }
+                        expect("format(10000000)", "1.0E7") { formatter.format(10000000) }
+                    } else {
+                        expect("format(0.0000001)", "1.0E-7") { formatter.format(0.0000001) }
+                        expect("format(12345.678)", "12,345.678") { formatter.format(12345.678) }
+                    }
+                }
+                workerFailures
+            }
+        }.awaitAll().flatten()
+
+        assertTrue(
+            failures.isEmpty(),
+            "${failures.size} corrupted results out of ${WORKERS * ITERATIONS * 2} operations; first: ${failures.take(5)}",
+        )
+    }
 }

--- a/base/formatting/src/commonTest/kotlin/formatting/NumberFormatterConcurrencyTest.kt
+++ b/base/formatting/src/commonTest/kotlin/formatting/NumberFormatterConcurrencyTest.kt
@@ -1,0 +1,80 @@
+/*
+ Copyright 2026 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.base.formatting
+
+import com.splendo.kaluga.base.i18n.KalugaLocale.Companion.createLocale
+import com.splendo.kaluga.base.test.BaseTest
+import com.splendo.kaluga.base.test.testRunBlocking
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class NumberFormatterConcurrencyTest : BaseTest() {
+
+    companion object {
+        private const val WORKERS = 8
+        private const val ITERATIONS = 10_000
+    }
+
+    @Test
+    fun testSharedFormatterFormatsAndParsesCorrectlyUnderContention() = testRunBlocking {
+        val formatter = NumberFormatter(createLocale("en", "US"), NumberFormatStyle.Decimal(minIntegerDigits = 1U, maxFractionDigits = 2U))
+
+        // Establish the single-threaded expectations first, so a failure below can only mean corruption.
+        assertEquals("0.8", formatter.format(0.8))
+        assertEquals("42", formatter.format(42))
+        assertEquals(10.0, formatter.parse("10")?.toDouble())
+        assertEquals(7.5, formatter.parse("7.5")?.toDouble())
+
+        val failures = (0 until WORKERS).map { worker ->
+            async(Dispatchers.Default) {
+                val workerFailures = mutableListOf<String>()
+
+                // A corrupted shared digit buffer can also make an operation throw (e.g. parse hitting
+                // NumberFormatException instead of ParseException), so exceptions count as corruption too.
+                fun expect(operation: String, expected: Any?, actual: () -> Any?) {
+                    val result = try {
+                        actual()
+                    } catch (e: Throwable) {
+                        "threw $e"
+                    }
+                    if (result != expected) workerFailures.add("$operation -> $result")
+                }
+                repeat(ITERATIONS) { iteration ->
+                    // Alternate which operation goes first per worker so format and parse overlap.
+                    if ((worker + iteration) % 2 == 0) {
+                        expect("format(0.8)", "0.8") { formatter.format(0.8) }
+                        expect("parse(\"10\")", 10.0) { formatter.parse("10")?.toDouble() }
+                    } else {
+                        expect("parse(\"7.5\")", 7.5) { formatter.parse("7.5")?.toDouble() }
+                        expect("format(42)", "42") { formatter.format(42) }
+                    }
+                }
+                workerFailures
+            }
+        }.awaitAll().flatten()
+
+        assertTrue(
+            failures.isEmpty(),
+            "${failures.size} corrupted results out of ${WORKERS * ITERATIONS * 2} operations; first: ${failures.take(5)}",
+        )
+    }
+}

--- a/base/formatting/src/jvmMain/kotlin/formatting/NumberFormatter.kt
+++ b/base/formatting/src/jvmMain/kotlin/formatting/NumberFormatter.kt
@@ -77,9 +77,18 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         is NumberFormatStyle.Pattern -> DecimalFormat("${style.positivePattern};${style.negativePattern}", DecimalFormatSymbols(locale.locale))
     } as DecimalFormat
 
+    // DecimalFormat is not thread-safe: format and parse share its internal digit buffer, so racing
+    // them on one instance corrupts results. Parsing therefore gets its own instance, making
+    // format/parse cross-contamination impossible while each path pays only a single (typically
+    // uncontended) monitor. The instances double as the locks, so they must stay private and never
+    // escape this class. Configuration writes go through [update] to both instances so the
+    // format/parse round-trip stays consistent.
+    private val parser = format.clone() as DecimalFormat
+
     // When the Scientific style sets a decimal-notation threshold, values within the threshold are
     // rendered with this plain decimal formatter instead; its mutable state is synced from `format`
-    // at format time so symbol/grouping overrides apply to both notations.
+    // at format time so symbol/grouping overrides apply to both notations. It is only ever touched
+    // while holding the `format` monitor.
     private val decimalThresholdStyle: NumberFormatStyle.Scientific? =
         (style as? NumberFormatStyle.Scientific)?.takeIf { it.maxExponentForDecimalNotation != null }
     private val decimalFallback: DecimalFormat? = decimalThresholdStyle?.decimalNotation?.let { decimal ->
@@ -91,11 +100,23 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         }
     }
 
-    private val symbols: DecimalFormatSymbols get() = format.decimalFormatSymbols
-    private fun applySymbols(apply: (DecimalFormatSymbols) -> Unit) {
-        val symbols = format.decimalFormatSymbols
+    // DecimalFormat.getDecimalFormatSymbols returns a copy, so it is safe to read outside the lock
+    // once obtained.
+    private val symbols: DecimalFormatSymbols get() = read { it.decimalFormatSymbols }
+    private inline fun <T> read(action: (DecimalFormat) -> T): T = synchronized(format) { action(format) }
+
+    // Nested in a fixed order (format then parse) so writes cannot deadlock and neither instance is
+    // observed mid-update by format or parse.
+    private inline fun update(action: (DecimalFormat) -> Unit) = synchronized(format) {
+        synchronized(parser) {
+            action(format)
+            action(parser)
+        }
+    }
+    private fun applySymbols(apply: (DecimalFormatSymbols) -> Unit) = update {
+        val symbols = it.decimalFormatSymbols
         apply(symbols)
-        format.decimalFormatSymbols = symbols
+        it.decimalFormatSymbols = symbols
     }
 
     init {
@@ -109,6 +130,7 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
             RoundingMode.Up -> java.math.RoundingMode.UP
         }
         format.roundingMode = javaRounding
+        parser.roundingMode = javaRounding
         decimalFallback?.roundingMode = javaRounding
     }
 
@@ -160,24 +182,24 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         }
 
     actual override var positivePrefix: String
-        get() = format.positivePrefix
+        get() = read { it.positivePrefix }
         set(value) {
-            format.positivePrefix = value
+            update { it.positivePrefix = value }
         }
     actual override var positiveSuffix: String
-        get() = format.positiveSuffix
+        get() = read { it.positiveSuffix }
         set(value) {
-            format.positiveSuffix = value
+            update { it.positiveSuffix = value }
         }
     actual override var negativePrefix: String
-        get() = format.negativePrefix
+        get() = read { it.negativePrefix }
         set(value) {
-            format.negativePrefix = value
+            update { it.negativePrefix = value }
         }
     actual override var negativeSuffix: String
-        get() = format.negativeSuffix
+        get() = read { it.negativeSuffix }
         set(value) {
-            format.negativeSuffix = value
+            update { it.negativeSuffix = value }
         }
 
     actual override var groupingSeparator: Char
@@ -188,10 +210,15 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
     actual override var usesGroupingSeparator: Boolean
         // The decimal fallback owns grouping so it groups like a normal decimal by default; the toggle
         // drives both notations.
-        get() = (decimalFallback ?: format).isGroupingUsed
+        get() = read { (decimalFallback ?: it).isGroupingUsed }
         set(value) {
-            format.isGroupingUsed = value
-            decimalFallback?.isGroupingUsed = value
+            synchronized(format) {
+                synchronized(parser) {
+                    format.isGroupingUsed = value
+                    parser.isGroupingUsed = value
+                }
+                decimalFallback?.isGroupingUsed = value
+            }
         }
     actual override var decimalSeparator: Char
         get() = symbols.decimalSeparator
@@ -199,9 +226,9 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
             applySymbols { it.decimalSeparator = value }
         }
     actual override var alwaysShowsDecimalSeparator: Boolean
-        get() = format.isDecimalSeparatorAlwaysShown
+        get() = read { it.isDecimalSeparatorAlwaysShown }
         set(value) {
-            format.isDecimalSeparatorAlwaysShown = value
+            update { it.isDecimalSeparatorAlwaysShown = value }
         }
     actual override var currencyDecimalSeparator: Char
         get() = symbols.monetaryDecimalSeparator
@@ -210,22 +237,27 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         }
     actual override var groupingSize: Int
         // The decimal fallback owns its grouping size (the scientific pattern has none); the setter drives both.
-        get() = (decimalFallback ?: format).groupingSize
+        get() = read { (decimalFallback ?: it).groupingSize }
         set(value) {
-            format.groupingSize = value
-            decimalFallback?.groupingSize = value
+            synchronized(format) {
+                synchronized(parser) {
+                    format.groupingSize = value
+                    parser.groupingSize = value
+                }
+                decimalFallback?.groupingSize = value
+            }
         }
     actual override var multiplier: Int
-        get() = format.multiplier
+        get() = read { it.multiplier }
         set(value) {
-            format.multiplier = value
+            update { it.multiplier = value }
         }
 
-    actual override fun format(number: Number): String {
+    actual override fun format(number: Number): String = synchronized(format) {
         val value = number.toDouble()
         val fallback = decimalFallback
         val scientific = decimalThresholdStyle
-        return if (fallback != null && scientific != null && scientific.rendersAsDecimal(value)) {
+        if (fallback != null && scientific != null && scientific.rendersAsDecimal(value)) {
             // Sync everything except grouping (which the fallback owns — see usesGroupingSeparator/groupingSize —
             // so it renders like a normal localized decimal regardless of scientific's no-grouping default).
             fallback.decimalFormatSymbols = format.decimalFormatSymbols
@@ -240,9 +272,11 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
             format.format(value)
         }
     }
-    actual override fun parse(string: String): Number? = try {
-        format.parse(string)
-    } catch (e: ParseException) {
-        null
+    actual override fun parse(string: String): Number? = synchronized(parser) {
+        try {
+            parser.parse(string)
+        } catch (e: ParseException) {
+            null
+        }
     }
 }

--- a/base/formatting/src/watchosArm64Main/kotlin/formatting/NumberFormatter.kt
+++ b/base/formatting/src/watchosArm64Main/kotlin/formatting/NumberFormatter.kt
@@ -116,8 +116,9 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
     }
 
     // When the Scientific style sets a decimal-notation threshold, values within the threshold are
-    // rendered with this plain decimal formatter instead; its mutable state is synced from `formatter`
-    // at format time so symbol/grouping overrides apply to both notations.
+    // rendered with this plain decimal formatter instead; it is synced from `formatter` once at
+    // construction and kept in sync by the property setters, so format never mutates it —
+    // NSNumberFormatter is only documented thread-safe for non-mutating use.
     private val decimalThresholdStyle: NumberFormatStyle.Scientific? =
         (style as? NumberFormatStyle.Scientific)?.takeIf { it.maxExponentForDecimalNotation != null }
     private val decimalFallback: NSNumberFormatter? = decimalThresholdStyle?.decimalNotation?.let { decimal ->
@@ -133,6 +134,12 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         }
     }
 
+    init {
+        decimalFallback?.let(::syncDecimalFallback)
+    }
+
+    // Construction-time only: copies the locale defaults the fallback shares with `formatter`. After
+    // this the property setters write through to both.
     private fun syncDecimalFallback(target: NSNumberFormatter) {
         target.decimalSeparator = formatter.decimalSeparator
         target.groupingSeparator = formatter.groupingSeparator
@@ -162,7 +169,9 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
     actual override var minusSign: Char
         get() = formatter.minusSign.getOrNull(0) ?: Char.MIN_VALUE
         set(value) {
-            formatter.minusSign = charArrayOf(value).concatToString()
+            val charValue = charArrayOf(value).concatToString()
+            formatter.minusSign = charValue
+            decimalFallback?.minusSign = charValue
         }
     actual override var exponentSymbol: String
         get() = formatter.exponentSymbol
@@ -172,18 +181,23 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
     actual override var zeroSymbol: Char
         get() = formatter.zeroSymbol?.getOrNull(0) ?: '0'
         set(value) {
-            formatter.zeroSymbol = charArrayOf(value).concatToString()
+            val charValue = charArrayOf(value).concatToString()
+            formatter.zeroSymbol = charValue
+            decimalFallback?.zeroSymbol = charValue
         }
     actual override var notANumberSymbol: String
         get() = formatter.notANumberSymbol
         set(value) {
             formatter.notANumberSymbol = value
+            decimalFallback?.notANumberSymbol = value
         }
     actual override var infinitySymbol: String
         get() = formatter.positiveInfinitySymbol
         set(value) {
             formatter.positiveInfinitySymbol = value
             formatter.negativeInfinitySymbol = value
+            decimalFallback?.positiveInfinitySymbol = value
+            decimalFallback?.negativeInfinitySymbol = value
         }
     actual override var currencySymbol: String
         get() = formatter.currencySymbol
@@ -199,21 +213,25 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         get() = formatter.positivePrefix
         set(value) {
             formatter.positivePrefix = value
+            decimalFallback?.positivePrefix = value
         }
     actual override var positiveSuffix: String
         get() = formatter.positiveSuffix
         set(value) {
             formatter.positiveSuffix = value
+            decimalFallback?.positiveSuffix = value
         }
     actual override var negativePrefix: String
         get() = formatter.negativePrefix
         set(value) {
             formatter.negativePrefix = value
+            decimalFallback?.negativePrefix = value
         }
     actual override var negativeSuffix: String
         get() = formatter.negativeSuffix
         set(value) {
             formatter.negativeSuffix = value
+            decimalFallback?.negativeSuffix = value
         }
     actual override var groupingSeparator: Char
         get() = formatter.groupingSeparator.getOrNull(0) ?: Char.MIN_VALUE
@@ -221,6 +239,7 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
             val charValue = charArrayOf(value).concatToString()
             formatter.groupingSeparator = charValue
             formatter.currencyGroupingSeparator = charValue
+            decimalFallback?.groupingSeparator = charValue
         }
     actual override var usesGroupingSeparator: Boolean
         // The decimal fallback owns grouping so it groups like a normal decimal by default; the toggle
@@ -233,12 +252,15 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
     actual override var decimalSeparator: Char
         get() = formatter.decimalSeparator.getOrNull(0) ?: Char.MIN_VALUE
         set(value) {
-            formatter.decimalSeparator = charArrayOf(value).concatToString()
+            val charValue = charArrayOf(value).concatToString()
+            formatter.decimalSeparator = charValue
+            decimalFallback?.decimalSeparator = charValue
         }
     actual override var alwaysShowsDecimalSeparator: Boolean
         get() = formatter.alwaysShowsDecimalSeparator
         set(value) {
             formatter.alwaysShowsDecimalSeparator = value
+            decimalFallback?.alwaysShowsDecimalSeparator = value
         }
     actual override var currencyDecimalSeparator: Char
         get() = formatter.currencyDecimalSeparator.getOrNull(0) ?: Char.MIN_VALUE
@@ -259,7 +281,9 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
     actual override var multiplier: Int
         get() = formatter.multiplier?.intValue ?: 1
         set(value) {
-            formatter.multiplier = NSNumber.numberWithInt(value)
+            val multiplierValue = NSNumber.numberWithInt(value)
+            formatter.multiplier = multiplierValue
+            decimalFallback?.multiplier = multiplierValue
         }
 
     @Suppress("CAST_NEVER_SUCCEEDS") // Should succeed just fine
@@ -267,7 +291,6 @@ actual class NumberFormatter actual constructor(actual override val locale: Kalu
         val fallback = decimalFallback
         val scientific = decimalThresholdStyle
         if (fallback != null && scientific != null && scientific.rendersAsDecimal(number.toDouble())) {
-            syncDecimalFallback(fallback)
             return fallback.stringFromNumber(number as NSNumber) ?: ""
         }
         return formatter.stringFromNumber(number as NSNumber) ?: ""

--- a/date-time/date-time/src/androidMain/kotlin/KalugaDateFormatter.kt
+++ b/date-time/date-time/src/androidMain/kotlin/KalugaDateFormatter.kt
@@ -78,16 +78,40 @@ actual class KalugaDateFormatter private constructor(private val format: SimpleD
         }
     }
 
-    private val symbols: DateFormatSymbols get() = format.dateFormatSymbols
+    // SimpleDateFormat is not thread-safe: format and parse both mutate the shared internal Calendar,
+    // so racing them on one instance corrupts results. Parsing therefore gets its own instance,
+    // making format/parse cross-contamination impossible while each path pays only a single
+    // (typically uncontended) monitor. The instances double as the locks, so they must stay private
+    // and never escape this class. Configuration writes go through [update] to both instances so the
+    // format/parse round-trip stays consistent. DateFormat.clone() deep-copies the calendar and
+    // symbols, so the two instances share no mutable state.
+    private val parser = format.clone() as SimpleDateFormat
+
+    // DateFormat.getDateFormatSymbols returns a copy, so it is safe to read outside the lock once
+    // obtained.
+    private val symbols: DateFormatSymbols get() = read { it.dateFormatSymbols }
+
+    private inline fun <T> read(action: (SimpleDateFormat) -> T): T = synchronized(format) { action(format) }
+
+    // Nested in a fixed order (format then parse) so writes cannot deadlock and neither instance is
+    // observed mid-update by format or parse.
+    private inline fun update(action: (SimpleDateFormat) -> Unit) = synchronized(format) {
+        synchronized(parser) {
+            action(format)
+            action(parser)
+        }
+    }
 
     actual override var pattern: String
-        get() = format.toPattern()
-        set(value) = format.applyPattern(value)
+        get() = read { it.toPattern() }
+        set(value) {
+            update { it.applyPattern(value) }
+        }
 
     actual override var timeZone: KalugaTimeZone
-        get() = KalugaTimeZone(format.timeZone)
+        get() = read { KalugaTimeZone(it.timeZone) }
         set(value) {
-            format.timeZone = value.timeZone
+            update { it.timeZone = value.timeZone }
         }
 
     actual override var eras: List<String>
@@ -153,12 +177,14 @@ actual class KalugaDateFormatter private constructor(private val format: SimpleD
             updateSymbols { it.amPmStrings = it.amPmStrings.toMutableList().apply { this[1] = value }.toTypedArray() }
         }
 
-    actual override fun format(date: KalugaDate): String = format.format(date.date)
-    actual override fun parse(string: String): KalugaDate? {
-        val currentTimeZone = timeZone
-        return try {
-            format.parse(string)?.let { date ->
-                val calendar = format.calendar.clone() as Calendar
+    actual override fun format(date: KalugaDate): String = synchronized(format) { format.format(date.date) }
+    actual override fun parse(string: String): KalugaDate? = synchronized(parser) {
+        // Read and restore against the parser's own zone; reading the format instance here would nest
+        // the locks in the reverse order of [update].
+        val currentTimeZone = KalugaTimeZone(parser.timeZone)
+        try {
+            parser.parse(string)?.let { date ->
+                val calendar = parser.calendar.clone() as Calendar
                 DefaultKalugaDate(
                     calendar.apply {
                         time = date
@@ -170,14 +196,14 @@ actual class KalugaDateFormatter private constructor(private val format: SimpleD
             null
         } finally {
             // Parse may change the timezone to the timezone parsed by the String. This restores the original timezone
-            timeZone = currentTimeZone
+            parser.timeZone = currentTimeZone.timeZone
         }
     }
 
-    private fun updateSymbols(transform: (DateFormatSymbols) -> Unit) {
-        val symbols = this.symbols
+    private fun updateSymbols(transform: (DateFormatSymbols) -> Unit) = update {
+        val symbols = it.dateFormatSymbols
         transform(symbols)
-        format.dateFormatSymbols = symbols
+        it.dateFormatSymbols = symbols
     }
 }
 

--- a/date-time/date-time/src/commonTest/kotlin/DateFormatterConcurrencyTest.kt
+++ b/date-time/date-time/src/commonTest/kotlin/DateFormatterConcurrencyTest.kt
@@ -1,0 +1,83 @@
+/*
+ Copyright 2026 Splendo Consulting B.V. The Netherlands
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.splendo.kaluga.datetime
+
+import com.splendo.kaluga.base.i18n.KalugaLocale
+import com.splendo.kaluga.base.i18n.enUsPosix
+import com.splendo.kaluga.base.test.testRunBlocking
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+class DateFormatterConcurrencyTest {
+
+    companion object {
+        private const val WORKERS = 8
+        private const val ITERATIONS = 10_000
+        private val March181988 = DefaultKalugaDate.epoch(574695462750.milliseconds)
+        private val Epoch = DefaultKalugaDate.epoch(0.milliseconds)
+    }
+
+    @Test
+    fun testSharedFormatterFormatsAndParsesCorrectlyUnderContention() = testRunBlocking {
+        val formatter = KalugaDateFormatter.patternFormat("yyyy-MM-dd HH:mm:ss", KalugaTimeZone.utc, KalugaLocale.enUsPosix)
+
+        // Establish the single-threaded expectations first, so a failure below can only mean corruption.
+        assertEquals("1988-03-18 13:37:42", formatter.format(March181988))
+        assertEquals("1970-01-01 00:00:00", formatter.format(Epoch))
+        assertEquals(1_000_000_000_000.milliseconds, formatter.parse("2001-09-09 01:46:40")?.durationSinceEpoch)
+        assertEquals(574695462000.milliseconds, formatter.parse("1988-03-18 13:37:42")?.durationSinceEpoch)
+
+        val failures = (0 until WORKERS).map { worker ->
+            async(Dispatchers.Default) {
+                val workerFailures = mutableListOf<String>()
+
+                // A corrupted shared calendar can also make an operation throw (e.g. parse hitting
+                // NumberFormatException instead of ParseException), so exceptions count as corruption too.
+                fun expect(operation: String, expected: Any?, actual: () -> Any?) {
+                    val result = try {
+                        actual()
+                    } catch (e: Throwable) {
+                        "threw $e"
+                    }
+                    if (result != expected) workerFailures.add("$operation -> $result")
+                }
+                repeat(ITERATIONS) { iteration ->
+                    // Alternate which operation goes first per worker so format and parse overlap.
+                    if ((worker + iteration) % 2 == 0) {
+                        expect("format(March181988)", "1988-03-18 13:37:42") { formatter.format(March181988) }
+                        expect("parse(\"2001-09-09 01:46:40\")", 1_000_000_000_000.milliseconds) { formatter.parse("2001-09-09 01:46:40")?.durationSinceEpoch }
+                    } else {
+                        expect("parse(\"1988-03-18 13:37:42\")", 574695462000.milliseconds) { formatter.parse("1988-03-18 13:37:42")?.durationSinceEpoch }
+                        expect("format(Epoch)", "1970-01-01 00:00:00") { formatter.format(Epoch) }
+                    }
+                }
+                workerFailures
+            }
+        }.awaitAll().flatten()
+
+        assertTrue(
+            failures.isEmpty(),
+            "${failures.size} corrupted results out of ${WORKERS * ITERATIONS * 2} operations; first: ${failures.take(5)}",
+        )
+    }
+}

--- a/date-time/date-time/src/jvmMain/kotlin/KalugaDateFormatter.kt
+++ b/date-time/date-time/src/jvmMain/kotlin/KalugaDateFormatter.kt
@@ -78,16 +78,40 @@ actual class KalugaDateFormatter private constructor(private val format: SimpleD
         }
     }
 
-    private val symbols: DateFormatSymbols get() = format.dateFormatSymbols
+    // SimpleDateFormat is not thread-safe: format and parse both mutate the shared internal Calendar,
+    // so racing them on one instance corrupts results. Parsing therefore gets its own instance,
+    // making format/parse cross-contamination impossible while each path pays only a single
+    // (typically uncontended) monitor. The instances double as the locks, so they must stay private
+    // and never escape this class. Configuration writes go through [update] to both instances so the
+    // format/parse round-trip stays consistent. DateFormat.clone() deep-copies the calendar and
+    // symbols, so the two instances share no mutable state.
+    private val parser = format.clone() as SimpleDateFormat
+
+    // DateFormat.getDateFormatSymbols returns a copy, so it is safe to read outside the lock once
+    // obtained.
+    private val symbols: DateFormatSymbols get() = read { it.dateFormatSymbols }
+
+    private inline fun <T> read(action: (SimpleDateFormat) -> T): T = synchronized(format) { action(format) }
+
+    // Nested in a fixed order (format then parse) so writes cannot deadlock and neither instance is
+    // observed mid-update by format or parse.
+    private inline fun update(action: (SimpleDateFormat) -> Unit) = synchronized(format) {
+        synchronized(parser) {
+            action(format)
+            action(parser)
+        }
+    }
 
     actual override var pattern: String
-        get() = format.toPattern()
-        set(value) = format.applyPattern(value)
+        get() = read { it.toPattern() }
+        set(value) {
+            update { it.applyPattern(value) }
+        }
 
     actual override var timeZone: KalugaTimeZone
-        get() = KalugaTimeZone(format.timeZone)
+        get() = read { KalugaTimeZone(it.timeZone) }
         set(value) {
-            format.timeZone = value.timeZone
+            update { it.timeZone = value.timeZone }
         }
 
     actual override var eras: List<String>
@@ -153,12 +177,14 @@ actual class KalugaDateFormatter private constructor(private val format: SimpleD
             updateSymbols { it.amPmStrings = it.amPmStrings.toMutableList().apply { this[1] = value }.toTypedArray() }
         }
 
-    actual override fun format(date: KalugaDate): String = format.format(date.date)
-    actual override fun parse(string: String): KalugaDate? {
-        val currentTimeZone = timeZone
-        return try {
-            format.parse(string)?.let { date ->
-                val calendar = format.calendar.clone() as Calendar
+    actual override fun format(date: KalugaDate): String = synchronized(format) { format.format(date.date) }
+    actual override fun parse(string: String): KalugaDate? = synchronized(parser) {
+        // Read and restore against the parser's own zone; reading the format instance here would nest
+        // the locks in the reverse order of [update].
+        val currentTimeZone = KalugaTimeZone(parser.timeZone)
+        try {
+            parser.parse(string)?.let { date ->
+                val calendar = parser.calendar.clone() as Calendar
                 DefaultKalugaDate(
                     calendar.apply {
                         time = date
@@ -170,14 +196,14 @@ actual class KalugaDateFormatter private constructor(private val format: SimpleD
             null
         } finally {
             // Parse may change the timezone to the timezone parsed by the String. This restores the original timezone
-            timeZone = currentTimeZone
+            parser.timeZone = currentTimeZone.timeZone
         }
     }
 
-    private fun updateSymbols(transform: (DateFormatSymbols) -> Unit) {
-        val symbols = this.symbols
+    private fun updateSymbols(transform: (DateFormatSymbols) -> Unit) = update {
+        val symbols = it.dateFormatSymbols
         transform(symbols)
-        format.dateFormatSymbols = symbols
+        it.dateFormatSymbols = symbols
     }
 }
 


### PR DESCRIPTION
Addresses the races described in #993. The androidMain and jvmMain actuals of `NumberFormatter` and `KalugaDateFormatter` split into a formatting and a parsing instance, each `synchronized` on itself, with configuration writing through to both. 

The apple `NumberFormatter`'s scientific decimal fallback is now synced at construction instead of on every format call, so format no longer mutates shared state. Contention tests in `commonTest` fail on the unfixed code (about 20% of mixed operations corrupted for numbers, two thirds for dates) and pass on JVM, Android host and the iOS simulator after.
